### PR TITLE
feat(auth): add opa-authz-proxy to fix authorization bypass

### DIFF
--- a/charts/auth/Chart.yaml
+++ b/charts/auth/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: auth
 description: Complete authentication stack with Kratos, Oathkeeper, OPAL, and OPAL-static
 type: application
-version: 0.1.8
+version: 0.1.9
 appVersion: "1.0.0"
 keywords:
   - auth

--- a/charts/auth/templates/_helpers.tpl
+++ b/charts/auth/templates/_helpers.tpl
@@ -126,6 +126,22 @@ vault.security.banzaicloud.io/vault-env-from-path: {{ .Values.global.vault.envFr
 {{- end -}}
 
 {{/*
+OPA AuthZ Proxy fullname
+*/}}
+{{- define "auth.opaAuthzProxy.fullname" -}}
+{{- printf "%s-opa-authz-proxy" (include "auth.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+OPA AuthZ Proxy selector labels
+*/}}
+{{- define "auth.opaAuthzProxy.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "auth.name" . }}-opa-authz-proxy
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: opa-authz-proxy
+{{- end }}
+
+{{/*
 Kratos Login UI fullname
 */}}
 {{- define "auth.kratosLoginUi.fullname" -}}

--- a/charts/auth/templates/opa-authz-proxy/deployment.yaml
+++ b/charts/auth/templates/opa-authz-proxy/deployment.yaml
@@ -1,0 +1,64 @@
+{{- if .Values.opaAuthzProxy.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "auth.opaAuthzProxy.fullname" . }}
+  labels:
+    {{- include "auth.labels" . | nindent 4 }}
+    app.kubernetes.io/component: opa-authz-proxy
+spec:
+  replicas: {{ .Values.opaAuthzProxy.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "auth.opaAuthzProxy.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "auth.opaAuthzProxy.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: opa-authz-proxy
+          image: "{{ .Values.opaAuthzProxy.image.repository }}:{{ .Values.opaAuthzProxy.image.tag }}"
+          imagePullPolicy: {{ .Values.opaAuthzProxy.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          env:
+            - name: OPA_UPSTREAM_URL
+              {{- if .Values.opaAuthzProxy.opaUpstreamUrl }}
+              value: {{ .Values.opaAuthzProxy.opaUpstreamUrl | quote }}
+              {{- else }}
+              value: "http://{{ .Release.Name }}-opal-client:{{ .Values.opal.client.opaPort }}"
+              {{- end }}
+            - name: LISTEN_ADDR
+              value: ":8080"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 3
+            periodSeconds: 5
+          resources:
+            {{- toYaml .Values.opaAuthzProxy.resources | nindent 12 }}
+{{- end }}

--- a/charts/auth/templates/opa-authz-proxy/service.yaml
+++ b/charts/auth/templates/opa-authz-proxy/service.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.opaAuthzProxy.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "auth.opaAuthzProxy.fullname" . }}
+  labels:
+    {{- include "auth.labels" . | nindent 4 }}
+    app.kubernetes.io/component: opa-authz-proxy
+spec:
+  type: {{ .Values.opaAuthzProxy.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.opaAuthzProxy.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "auth.opaAuthzProxy.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/auth/values.yaml
+++ b/charts/auth/values.yaml
@@ -192,7 +192,7 @@ oathkeeper:
         remote_json:
           enabled: true
           config:
-            remote: http://opal-client:8181/v1/data/rbac/allow
+            remote: http://opa-authz-proxy:8080/v1/data/rbac/allow
             payload: |
               {
                 "input": {
@@ -293,6 +293,33 @@ opalStatic:
   # If externalConfigMap is set, staticData is ignored
   # externalConfigMap: "my-opal-static-configmap"
   staticData: {}  # Map of filename -> content, e.g. { "bindings.json": "..." }
+
+# =============================================================================
+# OPA AuthZ Proxy - Translates OPA decisions into HTTP status codes
+# =============================================================================
+opaAuthzProxy:
+  enabled: true
+  replicaCount: 1
+
+  image:
+    repository: ghcr.io/w6d-io/infra/opa-authz-proxy
+    tag: "v0.1.0"
+    pullPolicy: IfNotPresent
+
+  # Auto-computed from opal client service if empty
+  opaUpstreamUrl: ""
+
+  service:
+    type: ClusterIP
+    port: 8080
+
+  resources:
+    requests:
+      cpu: 10m
+      memory: 16Mi
+    limits:
+      cpu: 50m
+      memory: 32Mi
 
 # =============================================================================
 # Webhook - Domain Validation Service (Optional)


### PR DESCRIPTION
## Summary

- **Critical security fix**: Oathkeeper `remote_json` authorizer checks HTTP status code, not JSON body. OPA always returns HTTP 200 regardless of allow/deny decision → all authenticated users were granted access to all routes.
- Adds `opa-authz-proxy` deployment + service that translates OPA `{"result": false}` → HTTP 403
- Wires Oathkeeper `remote_json.remote` to proxy instead of direct OPA
- Proxy image: `ghcr.io/w6d-io/infra/opa-authz-proxy:v0.1.0` ([source](https://github.com/w6d-io/opa-authz-proxy))
- Chart version bump: 0.1.8 → 0.1.9

## Test plan

- [ ] `helm template` renders proxy deployment, service, and correct Oathkeeper remote URL
- [ ] Deploy to dev-aws-1, verify `opa-authz-proxy` pod starts
- [ ] Test: unauthenticated user → 401 (unchanged)
- [ ] Test: authenticated user with no permissions → 403 (was 200, now fixed)
- [ ] Test: authenticated admin user → 200 (unchanged)
- [ ] Test: OPA unreachable → 502 (fail closed)