### PR TITLE
feat(opal): vendor OPAL subchart + podAnnotations for Vault

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /charts/*/charts
+!/charts/auth/charts/opal
 .idea
 .cr-release-packages/
 /config.json

--- a/charts/auth/Chart.lock
+++ b/charts/auth/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: kratos
   repository: https://k8s.ory.sh/helm/charts
-  version: 0.60.0
+  version: 0.61.0
 - name: oathkeeper
   repository: https://k8s.ory.sh/helm/charts
-  version: 0.60.0
-digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
-generated: "2026-04-16T10:00:00.000000000+02:00"
+  version: 0.61.0
+digest: sha256:a25e06f0f393f8d5ca9006d6aeb404b9bded8fed219cd7028f106536243d401f
+generated: "2026-04-16T10:56:30.283513138+02:00"

--- a/charts/auth/Chart.lock
+++ b/charts/auth/Chart.lock
@@ -5,5 +5,8 @@ dependencies:
 - name: oathkeeper
   repository: https://k8s.ory.sh/helm/charts
   version: 0.61.0
-digest: sha256:a25e06f0f393f8d5ca9006d6aeb404b9bded8fed219cd7028f106536243d401f
-generated: "2026-04-16T10:56:30.283513138+02:00"
+- name: opal
+  repository: file://charts/opal
+  version: 0.0.29
+digest: sha256:2884edd24c9ec7d287f79fb5fa1c4ffedda3f368e4d4d9d60861467014c5703a
+generated: "2026-04-16T10:59:04.667888654+02:00"

--- a/charts/auth/Chart.lock
+++ b/charts/auth/Chart.lock
@@ -5,8 +5,5 @@ dependencies:
 - name: oathkeeper
   repository: https://k8s.ory.sh/helm/charts
   version: 0.60.0
-- name: opal
-  repository: https://permitio.github.io/opal-helm-chart
-  version: 0.0.29
-digest: sha256:40447fa41762c7b7234794adc80cbebaff368a7492c08e1cdde4f7d1944fbd9f
-generated: "2025-12-23T17:09:54.289757353+01:00"
+digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
+generated: "2026-04-16T10:00:00.000000000+02:00"

--- a/charts/auth/Chart.yaml
+++ b/charts/auth/Chart.yaml
@@ -34,5 +34,8 @@ dependencies:
     condition: oathkeeper.enabled
 
   # OPAL - Policy Administration (Server + Client + OPA)
-  # Vendored in charts/opal/ for custom template modifications (podAnnotations for Vault)
-  # Original: https://permitio.github.io/opal-helm-chart
+  # Vendored for custom template modifications (podAnnotations for Vault)
+  - name: opal
+    version: "0.0.29"
+    repository: "file://charts/opal"
+    condition: opal.enabled

--- a/charts/auth/Chart.yaml
+++ b/charts/auth/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: auth
 description: Complete authentication stack with Kratos, Oathkeeper, OPAL, and OPAL-static
 type: application
-version: 0.1.9
+version: 0.1.10
 appVersion: "1.0.0"
 keywords:
   - auth
@@ -34,7 +34,5 @@ dependencies:
     condition: oathkeeper.enabled
 
   # OPAL - Policy Administration (Server + Client + OPA)
-  - name: opal
-    version: "*"
-    repository: https://permitio.github.io/opal-helm-chart
-    condition: opal.enabled
+  # Vendored in charts/opal/ for custom template modifications (podAnnotations for Vault)
+  # Original: https://permitio.github.io/opal-helm-chart

--- a/charts/auth/charts/opal/.helmignore
+++ b/charts/auth/charts/opal/.helmignore
@@ -1,0 +1,42 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+
+venv
+*.tgz
+.github
+*.py
+*.adoc
+*.txt
+.release-it.json
+*.adoc
+skaffold.yaml
+values-lint.yaml
+node_modules
+README.adoc
+package-lock.json
+*.puml
+.editorconfig
+.dockerignore
+cmak2zk/
+

--- a/charts/auth/charts/opal/Chart.yaml
+++ b/charts/auth/charts/opal/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+appVersion: 0.7.12
+icon: https://www.opal.ac/icons/icon-192x192.png
+kubeVersion: '>= 1.18.0-0'
+name: opal
+type: application
+version: 0.0.29

--- a/charts/auth/charts/opal/LICENSE
+++ b/charts/auth/charts/opal/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/charts/auth/charts/opal/README.md
+++ b/charts/auth/charts/opal/README.md
@@ -1,0 +1,81 @@
+<p  align="center">
+ <img src="https://i.ibb.co/BGVBmMK/opal.png" height=100 alt="opal" border="0" />
+</p>
+<h2 align="center">
+OPAL Helm Chart for Kubernetes
+</h2>
+
+OPAL is an administration layer for Open Policy Agent (OPA), detecting changes to both policy and policy data in realtime and pushing live updates to your agents.
+
+OPAL brings open-policy up to the speed needed by live applications. As your application state changes (whether it's via your APIs, DBs, git, S3 or 3rd-party SaaS services), OPAL will make sure your services are always in sync with the authorization data and policy they need (and only those they need).
+
+[Check out OPAL main repo here.](https://github.com/permitio/opal)
+
+### Installation
+
+OPAL Helm chart could be installed only with [Helm 3](https://helm.sh/docs/).
+The chart is published to public Helm repository, [hosted on GitHub itself](https://permitio.github.io/opal-helm-chart/). It's recommended to install OPAL into a dedicated namespace.
+
+Add Helm repository
+
+```
+helm repo add permitio https://permitio.github.io/opal-helm-chart
+helm repo update
+```
+
+Install the latest version
+
+```
+helm install --create-namespace -n opal-ns opal permitio/opal
+```
+
+Search for all available versions
+
+```
+helm search repo opal --versions
+```
+
+### Deploy OPAL to your Kubernetes cluster
+
+Install specific version (with default configuration):
+
+```
+helm install --create-namespace -n opal-ns --version x.x.x opal permitio/opal
+```
+
+Install specific version (with custom configuration provided as YAML):
+
+```
+helm install -f myvalues.yaml --create-namespace -n opal-ns --version x.x.x opal permitio/opal
+```
+
+`myvalues.yaml` must conform to the [json schema](https://raw.githubusercontent.com/permitio/opal-helm-chart/master/values.schema.json).
+
+### Verify installation
+
+OPAL Client should populate embedded OPA instance with polices and data from configured Git repository.
+To validate it - one could create port-forwarding to OPAL client Pod. Port 8181 is the embedded OPA agent.
+
+```
+kubectl port-forward -n opal-ns service/opal-client 8181:8181
+```
+
+Then, open http://localhost:8181/v1/data/ in your browser to check OPA data document state.
+
+### Important Configuration
+
+This is not a comprehensive list, but includes the main variables you have to think about
+
+| Variable                                       | Description                                                                                                                                      |
+| ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `server.policyRepoUrl`                         | Git repository holding policy code (& optionally policy data) to be tracked by OPAL                                                              |
+| `server.dataConfigSources`                     | Data sources to be published to clients (and their managed OPAs)                                                                                 |
+| `server.dataConfigSources.config.entries`      | Static list of data source entries (See [OPAL Docs](https://docs.opal.ac/getting-started/running-opal/run-opal-server/data-sources))             |
+| `server.dataConfigSources.external_source_url` | URL to dynamically fetch data sources entries from (See [OPAL Docs](https://docs.opal.ac/tutorials/configure_external_data_sources))             |
+| `server.broadcastUri`                          | Backend for broadcasting updates across multiple opal-server processes (necessary if either `server.uvicornWorkers` or `server.replicas` is > 1) |
+| `server.uvicornWorkers`                        | Count of gunicorn workers (/processes) per opal-server replica                                                                                   |
+| `server.replicas`                              | opal-server's deployment replica count                                                                                                           |
+| `server.extraEnv`                              | Extra configuration for opal-server (see [OPAL Docs](https://docs.opal.ac/tutorials/configure_opal))                                             |
+| `client.extraEnv`                              | Extra configuration for opal-server [OPAL Docs](https://docs.opal.ac/tutorials/configure_opal)                                                   |
+
+**Note:** If you leave `server.dataConfigSources` with no entries - The chart would automatically set `OPAL_DATA_UPDATER_ENABLED: False` in `client.extraEnv` so client won't report an unhealthy state.

--- a/charts/auth/charts/opal/templates/_utils.tpl
+++ b/charts/auth/charts/opal/templates/_utils.tpl
@@ -1,0 +1,83 @@
+{{- define "opal.serverName" -}}
+{{- if eq .Release.Name .Chart.Name }}
+{{- printf "%s-server" .Release.Name  }}
+{{- else }}
+{{- printf "%s-%s-server" .Release.Name .Chart.Name }}
+{{- end -}}
+{{- end -}}
+
+{{- define "opal.clientName" -}}
+{{- if eq .Release.Name .Chart.Name }}
+{{- printf "%s-client" .Release.Name  }}
+{{- else }}
+{{- printf "%s-%s-client" .Release.Name .Chart.Name }}
+{{- end -}}
+{{- end -}}
+
+{{- define "opal.pgsqlName" -}}
+{{- if eq .Release.Name .Chart.Name }}
+{{- printf "%s-pgsql" .Release.Name  }}
+{{- else }}
+{{- printf "%s-%s-pgsql" .Release.Name .Chart.Name }}
+{{- end -}}
+{{- end -}}
+
+{{- define "opal.serverImage" -}}
+{{- printf "%s/%s:%s" (default "docker.io" .Values.image.server.registry) (default "permitio/opal-server" .Values.image.server.repository) (default .Chart.AppVersion .Values.image.server.tag) }}
+{{- end -}}
+
+{{- define "opal.clientImage" -}}
+{{- printf "%s/%s:%s" (default "docker.io" .Values.image.client.registry) (default "permitio/opal-client" .Values.image.client.repository) (default .Chart.AppVersion .Values.image.client.tag) }}
+{{- end -}}
+
+{{- define "opal.pgsqlImage" -}}
+{{- printf "%s/%s:%s" (default "docker.io" .Values.image.pgsql.registry) (default "postgres" .Values.image.pgsql.repository) (default "alpine" .Values.image.pgsql.tag) }}
+{{- end -}}
+
+{{- define "opal.envSecretsName" -}}
+{{- if eq .Release.Name .Chart.Name }}
+{{- printf "%s-env-secrets" .Release.Name  }}
+{{- else }}
+{{- printf "%s-%s-env-secrets" .Release.Name .Chart.Name }}
+{{- end -}}
+{{- end -}}
+
+{{- define "opal.clientSelectorLabels" -}}
+app.kubernetes.io/name: {{ include "opal.clientName" . | quote }}
+app.kubernetes.io/instance: {{ .Release.Name | quote }}
+opal.ac/role: client
+{{- end -}}
+
+{{- define "opal.serverSelectorLabels" -}}
+app.kubernetes.io/name: {{ include "opal.serverName" . | quote }}
+app.kubernetes.io/instance: {{ .Release.Name | quote }}
+opal.ac/role: server
+{{- end -}}
+
+{{- define "opal.pgsqlSelectorLabels" -}}
+app.kubernetes.io/name: {{ include "opal.pgsqlName" . | quote }}
+app.kubernetes.io/instance: {{ .Release.Name | quote }}
+opal.ac/role: pgsql
+{{- end -}}
+
+{{- define "opal.clientLabels" -}}
+app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | quote }}
+{{ include "opal.clientSelectorLabels" . }}
+{{- end -}}
+
+{{- define "opal.serverLabels" -}}
+app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | quote }}
+{{ include "opal.serverSelectorLabels" . }}
+{{- end -}}
+
+{{- define "opal.pgsqlLabels" -}}
+app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | quote }}
+{{ include "opal.pgsqlSelectorLabels" . }}
+{{- end -}}
+

--- a/charts/auth/charts/opal/templates/cm.yaml
+++ b/charts/auth/charts/opal/templates/cm.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.e2e }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: policy-repo-data
+data:
+  upd.sh: |
+    {{- .Files.Get "test/e2e/upd.sh" | nindent 4 }}
+  data.json: |
+    {{- .Files.Get "test/e2e/data.json" | nindent 4 }}
+  rbac.rego: |
+    {{- .Files.Get "test/e2e/rbac.rego" | nindent 4 }}
+{{- end }}
+---
+{{- if .Values.client }}
+{{- if .Values.client.opaStartupData }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: opa-startup-data
+data:
+  {{- range $name, $value := .Values.client.opaStartupData }}
+  {{ $name }}: |
+    {{ $value |  nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/auth/charts/opal/templates/deployment-client.yaml
+++ b/charts/auth/charts/opal/templates/deployment-client.yaml
@@ -1,0 +1,118 @@
+{{- if .Values.client }}
+{{- if ne .Values.client.enabled false  }}
+{{- $nm := include "opal.clientName" . | quote }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $nm }}
+  labels:
+    {{- include "opal.clientLabels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.client.replicas }}
+  selector:
+    matchLabels:
+      {{- include "opal.clientSelectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "opal.clientLabels" . | nindent 8 }}
+      {{- with .Values.client.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.image.client.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if or .Values.openshift.enabled .Values.client.securityContext }}
+      securityContext:
+        {{- if .Values.client.securityContext }}
+        {{- toYaml .Values.client.securityContext | nindent 8 }}
+        {{- else if .Values.openshift.enabled }}
+        {{- toYaml .Values.openshift.securityContext | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      {{- if .Values.client.opaStartupData }}
+      volumes:
+        - name: opa-startup-data
+          configMap:
+            name: opa-startup-data
+            defaultMode: 0444
+      {{- end }}
+      containers:
+        - name: opal-client
+          image: {{ include "opal.clientImage" . | quote }}
+          imagePullPolicy: {{ .Values.client.imagePullPolicy | default "IfNotPresent" | quote }}
+          {{- if or .Values.openshift.enabled .Values.client.containerSecurityContext }}
+          securityContext:
+            {{- if .Values.client.containerSecurityContext }}
+            {{- toYaml .Values.client.containerSecurityContext | nindent 12 }}
+            {{- else if .Values.openshift.enabled }}
+            {{- toYaml .Values.openshift.containerSecurityContext | nindent 12 }}
+            {{- end }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.client.port }}
+              protocol: TCP
+            - name: opa
+              containerPort: {{ .Values.client.opaPort }}
+              protocol: TCP
+          env:
+            - name: UVICORN_NUM_WORKERS
+              value: "1"
+          {{- if .Values.server }}
+            {{- if .Values.client.serverUrl }}
+            - name: OPAL_SERVER_URL
+              value: {{ .Values.client.serverUrl | quote }}
+            {{- else }}
+            - name: OPAL_SERVER_URL
+              value: {{ printf "http://%s:%v" (include "opal.serverName" .) .Values.server.port | quote }}
+            {{- end}}
+            {{- if not (or (.Values.server.dataConfigSources.external_source_url) (and .Values.server.dataConfigSources.config .Values.server.dataConfigSources.config.entries) (hasKey .Values.client.extraEnv "OPAL_DATA_UPDATER_ENABLED") ) }}
+            - name: OPAL_DATA_UPDATER_ENABLED
+              value: "False"
+            {{- end }}
+          {{- end }}
+          {{- if .Values.client.extraEnv }}
+          {{- range $name, $value := .Values.client.extraEnv }}
+            - name: {{ $name }}
+              value: {{ $value | quote }}
+          {{- end }}
+          {{- end }}
+          {{- if .Values.client.secrets }}
+          envFrom:
+          {{- range $name := .Values.client.secrets }}
+            - secretRef:
+                name: {{ $name }}
+          {{- end }}
+          {{- end }}
+          {{- if .Values.client.opaStartupData }}
+          volumeMounts:
+            - mountPath: /opt/opa/startup-data
+              name: opa-startup-data
+              readOnly: true
+          {{- end }}
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: http
+            failureThreshold: 5
+            initialDelaySeconds: 5
+            timeoutSeconds: 10
+            periodSeconds: 15
+
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: http
+            failureThreshold: 5
+            timeoutSeconds: 10
+            periodSeconds: 30
+          {{- if .Values.client.resources }}
+          resources:
+            {{- toYaml .Values.client.resources | nindent 12 }}
+          {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/auth/charts/opal/templates/deployment-pgsql.yaml
+++ b/charts/auth/charts/opal/templates/deployment-pgsql.yaml
@@ -1,0 +1,75 @@
+{{- if .Values.server }}
+{{- if and .Values.server.broadcastPgsql (not .Values.server.broadcastUri) }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "opal.pgsqlName" . }}
+  labels:
+    {{- include "opal.pgsqlLabels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.broadcastReplicas }}
+  selector:
+    matchLabels:
+      {{- include "opal.pgsqlSelectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "opal.pgsqlLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.image.client.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if or .Values.openshift.enabled .Values.postgresql.securityContext }}
+      securityContext:
+        {{- if .Values.postgresql.securityContext }}
+        {{- toYaml .Values.postgresql.securityContext | nindent 8 }}
+        {{- else if .Values.openshift.enabled }}
+        {{- toYaml .Values.openshift.securityContext | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      {{- if .Values.openshift.enabled }}
+      volumes:
+        - name: postgres-data
+          emptyDir: {}
+      {{- end }}
+      containers:
+        - name: pgsql
+          image: {{ include "opal.pgsqlImage" . | quote }}
+          imagePullPolicy: IfNotPresent
+          {{- if or .Values.openshift.enabled .Values.postgresql.containerSecurityContext }}
+          securityContext:
+            {{- if .Values.postgresql.containerSecurityContext }}
+            {{- toYaml .Values.postgresql.containerSecurityContext | nindent 12 }}
+            {{- else if .Values.openshift.enabled }}
+            {{- toYaml .Values.openshift.containerSecurityContext | nindent 12 }}
+            {{- end }}
+          {{- end }}
+          {{- if .Values.openshift.enabled }}
+          volumeMounts:
+            - mountPath: /var/lib/postgresql/data
+              name: postgres-data
+          {{- end }}
+          ports:
+            - name: pgsql
+              containerPort: 5432
+              protocol: TCP
+          env:
+            - name: POSTGRES_DB
+              value: postgres
+            - name: POSTGRES_USER
+              value: postgres
+            - name: POSTGRES_PASSWORD
+              value: postgres
+            {{- if .Values.openshift.enabled }}
+            - name: PGDATA
+              value: "/var/lib/postgresql/data/pgdata"
+            {{- end }}
+            {{- if .Values.postgresql.extraEnv }}
+            {{- range $name, $value := .Values.postgresql.extraEnv }}
+            - name: {{ $name }}
+              value: {{ $value | quote }}
+            {{- end }}
+            {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/auth/charts/opal/templates/deployment-server.yaml
+++ b/charts/auth/charts/opal/templates/deployment-server.yaml
@@ -1,0 +1,183 @@
+{{- if .Values.server }}
+{{- if ne .Values.server.enabled false  }}
+{{- $nm := include "opal.serverName" . | quote }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $nm }}
+  labels:
+    {{- include "opal.serverLabels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.server.replicas }}
+  selector:
+    matchLabels:
+      {{- include "opal.serverSelectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "opal.serverLabels" . | nindent 8 }}
+      {{- with .Values.server.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.image.server.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if or .Values.openshift.enabled .Values.server.securityContext }}
+      securityContext:
+        {{- if .Values.server.securityContext }}
+        {{- toYaml .Values.server.securityContext | nindent 8 }}
+        {{- else if .Values.openshift.enabled }}
+        {{- toYaml .Values.openshift.securityContext | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      {{- if .Values.e2e }}
+      volumes:
+        - name: e2e
+          emptyDir: {}
+        - name: policy-repo-data
+          configMap:
+            name: policy-repo-data
+            defaultMode: 0755
+      {{- else if .Values.openshift.enabled }}
+      volumes:
+        - name: jwks-dir
+          emptyDir: {}
+      {{- end }}
+
+      {{- if .Values.e2e }}
+      initContainers:
+        - name: git-init
+          image: {{ include "opal.serverImage" . | quote }}
+          imagePullPolicy: IfNotPresent
+          {{- if or .Values.openshift.enabled .Values.server.containerSecurityContext }}
+          securityContext:
+            {{- if .Values.server.containerSecurityContext }}
+            {{- toYaml .Values.server.containerSecurityContext | nindent 12 }}
+            {{- else if .Values.openshift.enabled }}
+            {{- toYaml .Values.openshift.containerSecurityContext | nindent 12 }}
+            {{- end }}
+          {{- end }}
+          volumeMounts:
+            - mountPath: /opt/e2e
+              name: e2e
+            - mountPath: /opt/e2e/policy-repo-data
+              name: policy-repo-data
+              readOnly: true
+          command:
+            - '/bin/sh'
+            - '-c'
+            - |
+              set -x
+              set -e
+
+              git init --bare /opt/e2e/policy-repo.git
+              git clone /opt/e2e/policy-repo.git /opt/e2e/policy-repo-working
+              cp /opt/e2e/policy-repo-data/*.* /opt/e2e/policy-repo-working
+              cd /opt/e2e/policy-repo-working
+              git config user.email "opal@opal.ac"
+              git config user.name "Opal Bot"
+              git add .
+              git commit -am 'chore: initial'
+              git push
+
+              echo ">>>> HEAD: $(git rev-parse --short HEAD) <<<<"
+      {{- end }}
+      containers:
+        - name: opal-server
+          image: {{ include "opal.serverImage" . | quote }}
+          imagePullPolicy: {{ .Values.server.imagePullPolicy | default "IfNotPresent" | quote }}
+          {{- if or .Values.openshift.enabled .Values.server.containerSecurityContext }}
+          securityContext:
+            {{- if .Values.server.containerSecurityContext }}
+            {{- toYaml .Values.server.containerSecurityContext | nindent 12 }}
+            {{- else if .Values.openshift.enabled }}
+            {{- toYaml .Values.openshift.containerSecurityContext | nindent 12 }}
+            {{- end }}
+          {{- end }}
+          {{- if .Values.e2e }}
+          volumeMounts:
+            - mountPath: /opt/e2e/policy-repo-data
+              name: policy-repo-data
+              readOnly: true
+            - mountPath: /opt/e2e
+              name: e2e
+          {{- else if .Values.openshift.enabled }}
+          volumeMounts:
+            - mountPath: /opal/jwks_dir
+              name: jwks-dir
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.server.port }}
+              protocol: TCP
+          env:
+            - name: OPAL_POLICY_REPO_URL
+              value: {{ .Values.server.policyRepoUrl | quote }}
+            - name: OPAL_POLICY_REPO_POLLING_INTERVAL
+              value: {{ .Values.server.pollingInterval | quote }}
+            {{- if .Values.server.policyRepoClonePath }}
+            - name: OPAL_POLICY_REPO_CLONE_PATH
+              value: {{ .Values.server.policyRepoClonePath | quote }}
+            {{- end }}
+            {{- if .Values.server.policyRepoMainBranch }}
+            - name: OPAL_POLICY_REPO_MAIN_BRANCH
+              value: {{ .Values.server.policyRepoMainBranch | quote }}
+            {{- end }}
+            - name: UVICORN_NUM_WORKERS
+              value: {{ .Values.server.uvicornWorkers | quote }}
+            {{- if .Values.server.dataConfigSources.external_source_url }}
+            - name: OPAL_DATA_CONFIG_SOURCES
+              value: {{ dict "external_source_url" .Values.server.dataConfigSources.external_source_url | toRawJson | squote }}
+            {{- else if and .Values.server.dataConfigSources.config .Values.server.dataConfigSources.config.entries }}
+            - name: OPAL_DATA_CONFIG_SOURCES
+              value: {{ dict "config" .Values.server.dataConfigSources.config | toRawJson | squote }}
+            {{- end}}
+            {{- if .Values.server.broadcastUri }}
+            - name: OPAL_BROADCAST_URI
+              value: {{ .Values.server.broadcastUri | quote }}
+            {{- else if .Values.server.broadcastPgsql }}
+            - name: OPAL_BROADCAST_URI
+              value: 'postgres://postgres:postgres@{{ include "opal.pgsqlName" . }}:5432/postgres'
+            {{- end }}
+            {{- if .Values.server.extraEnv }}
+            {{- range $name, $value := .Values.server.extraEnv }}
+            - name: {{ $name }}
+              value: {{ $value | quote }}
+            {{- end }}
+            {{- end }}
+          {{- if or .Values.server.secrets .Values.server.policyRepoSshKey }}
+          envFrom:
+          {{- range $name := .Values.server.secrets }}
+            - secretRef:
+                name: {{ $name }}
+          {{- end }}
+          {{- if .Values.server.policyRepoSshKey }}
+            - secretRef:
+                name: {{ include "opal.envSecretsName" . }}
+          {{- end }}
+          {{- end }}
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: http
+            failureThreshold: 5
+            initialDelaySeconds: 5
+            timeoutSeconds: 10
+            periodSeconds: 15
+
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: http
+            failureThreshold: 5
+            timeoutSeconds: 10
+            periodSeconds: 30
+          {{- if .Values.server.resources }}
+          resources:
+            {{- toYaml .Values.server.resources | nindent 12 }}
+          {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/auth/charts/opal/templates/secret-envsecrets.yaml
+++ b/charts/auth/charts/opal/templates/secret-envsecrets.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.server.policyRepoSshKey }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "opal.envSecretsName" . }}
+type: Opaque
+data:
+  OPAL_POLICY_REPO_SSH_KEY: {{ .Values.server.policyRepoSshKey | replace "\n" "_" | b64enc }}
+{{- end }}

--- a/charts/auth/charts/opal/templates/service-client.yaml
+++ b/charts/auth/charts/opal/templates/service-client.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.client }}
+{{- if ne .Values.client.enabled false  }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "opal.clientName" . }}
+  labels:
+    {{- include "opal.clientLabels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: {{ .Values.client.port }}
+      targetPort: http
+      protocol: TCP
+    - name: opa
+      port: {{ .Values.client.opaPort }}
+      targetPort: opa
+      protocol: TCP
+  selector:
+    {{- include "opal.clientSelectorLabels" . | nindent 4 }}
+
+{{- end }}
+{{- end }}

--- a/charts/auth/charts/opal/templates/service-pgsql.yaml
+++ b/charts/auth/charts/opal/templates/service-pgsql.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.server }}
+{{- if and .Values.server.broadcastPgsql (not .Values.server.broadcastUri) }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "opal.pgsqlName" . | quote }}
+  labels:
+    {{- include "opal.pgsqlLabels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: pgsql
+      port: 5432
+      targetPort: pgsql
+      protocol: TCP
+  selector:
+    {{- include "opal.pgsqlSelectorLabels" . | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/charts/auth/charts/opal/templates/service-server.yaml
+++ b/charts/auth/charts/opal/templates/service-server.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.server }}
+{{- if ne .Values.server.enabled false  }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "opal.serverName" . | quote }}
+  labels:
+    {{- include "opal.serverLabels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: {{ .Values.server.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "opal.serverSelectorLabels" . | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/charts/auth/charts/opal/templates/tests/e2e.yaml
+++ b/charts/auth/charts/opal/templates/tests/e2e.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.client }}
+{{- $url := printf "http://%v:%v/v1/data" (include "opal.clientName" .) .Values.client.opaPort -}}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: opal-e2e
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  restartPolicy: Never
+  containers:
+  - name: e2e
+    image: "apteno/alpine-jq:2021-04-25"
+    command:
+    - '/bin/sh'
+    - '-c'
+    - |
+      set -x
+      set -e
+
+      sleep 15
+
+      [ "$(curl -s {{ $url }} | jq '.result.users | keys | length')" -eq 3 ]
+      [ "$(curl -s {{ $url }} | jq '.result.role_permissions | keys | length')" -eq 3 ]
+{{- end }}

--- a/charts/auth/charts/opal/test/e2e/data.json
+++ b/charts/auth/charts/opal/test/e2e/data.json
@@ -1,0 +1,80 @@
+{
+    "users": {
+        "alice": {
+            "roles": [
+                "admin"
+            ],
+            "location": {
+                "country": "US",
+                "ip": "8.8.8.8"
+            }
+        },
+        "bob": {
+            "roles": [
+                "employee",
+                "billing"
+            ],
+            "location": {
+                "country": "US",
+                "ip": "8.8.8.8"
+            }
+        },
+        "eve": {
+            "roles": [
+                "customer"
+            ],
+            "location": {
+                "country": "US",
+                "ip": "8.8.8.8"
+            }
+        }
+    },
+    "role_permissions": {
+        "customer": [
+            {
+                "action": "read",
+                "type": "dog"
+            },
+            {
+                "action": "read",
+                "type": "cat"
+            },
+            {
+                "action": "adopt",
+                "type": "dog"
+            },
+            {
+                "action": "adopt",
+                "type": "cat"
+            }
+        ],
+        "employee": [
+            {
+                "action": "read",
+                "type": "dog"
+            },
+            {
+                "action": "read",
+                "type": "cat"
+            },
+            {
+                "action": "update",
+                "type": "dog"
+            },
+            {
+                "action": "update",
+                "type": "cat"
+            }
+        ],
+        "billing": [
+            {
+                "action": "read",
+                "type": "finance"
+            },
+            {
+                "action": "update",
+                "type": "finance"
+            }
+        ]
+    }
+}

--- a/charts/auth/charts/opal/test/e2e/deploy.sh
+++ b/charts/auth/charts/opal/test/e2e/deploy.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -x
+set -e
+
+if [ -z $MSYSTEM ]; then
+  helm upgrade --install --wait --create-namespace -n opal myopal . \
+    --set e2e=true --set server.pollingInterval=5 \
+    --set server.policyRepoUrl='/opt/e2e/policy-repo.git'
+else
+  helm upgrade --install --wait --create-namespace -n opal myopal . \
+    --set e2e=true --set server.pollingInterval=5 \
+    --set server.policyRepoUrl='//opt/e2e/policy-repo.git'
+fi
+
+kubectl logs -n opal service/myopal-opal-server git-init

--- a/charts/auth/charts/opal/test/e2e/k3d.yaml
+++ b/charts/auth/charts/opal/test/e2e/k3d.yaml
@@ -1,0 +1,20 @@
+apiVersion: k3d.io/v1alpha4
+kind: Simple
+metadata:
+  name: k3d
+image: rancher/k3s:v1.28.8-k3s1
+options:
+  k3d:
+    wait: true
+    disableLoadbalancer: true
+  k3s:
+    extraArgs:
+      - arg: --disable=metrics-server
+        nodeFilters:
+          - server:*
+      - arg: --disable=servicelb
+        nodeFilters:
+          - server:*
+      - arg: --disable=traefik
+        nodeFilters:
+          - server:*

--- a/charts/auth/charts/opal/test/e2e/rbac.rego
+++ b/charts/auth/charts/opal/test/e2e/rbac.rego
@@ -1,0 +1,65 @@
+# Role-based Access Control (RBAC)
+# --------------------------------
+#
+# This example defines an RBAC model for a Pet Store API. The Pet Store API allows
+# users to look at pets, adopt them, update their stats, and so on. The policy
+# controls which users can perform actions on which resources. The policy implements
+# a classic Role-based Access Control model where users are assigned to roles and
+# roles are granted the ability to perform some action(s) on some type of resource.
+#
+# This example shows how to:
+#
+#	* Define an RBAC model in Rego that interprets role mappings represented in JSON.
+#	* Iterate/search across JSON data structures (e.g., role mappings)
+#
+# For more information see:
+#
+#	* Rego comparison to other systems: https://www.openpolicyagent.org/docs/latest/comparison-to-other-systems/
+#	* Rego Iteration: https://www.openpolicyagent.org/docs/latest/#iteration
+
+package app.rbac
+
+# By default, deny requests.
+default allow = false
+
+# Allow admins to do anything.
+allow {
+	user_is_admin
+}
+
+# Allow the action if the user is granted permission to perform the action.
+allow {
+	# Find permissions for the user.
+	some permission
+	user_is_granted[permission]
+
+	# Check if the permission permits the action.
+	input.action == permission.action
+	input.type == permission.type
+    
+    # unless user location is outside US
+    country := data.users[input.user]["location"]["country"]
+    country == "US"
+}
+
+# user_is_admin is true if...
+user_is_admin {
+
+	# for some `i`...
+	some i
+
+	# "admin" is the `i`-th element in the user->role mappings for the identified user.
+	data.users[input.user]["roles"][i] == "admin"
+}
+
+# user_is_granted is a set of permissions for the user identified in the request.
+# The `permission` will be contained if the set `user_is_granted` for every...
+user_is_granted[permission] {
+	some i, j
+
+	# `role` assigned an element of the user_roles for this user...
+	role := data.users[input.user]["roles"][i]
+
+	# `permission` assigned a single permission from the permissions list for 'role'...
+	permission := data.role_permissions[role][j]
+}

--- a/charts/auth/charts/opal/test/e2e/test.sh
+++ b/charts/auth/charts/opal/test/e2e/test.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -x
+set -e
+
+helm test -n opal --logs myopal
+
+DATA_URL="http://myopal-opal-client:8181/v1/data"
+
+# Check that users data is present initially
+RESULT=$(kubectl run -n opal curl-test --image=curlimages/curl:latest --rm -i --restart=Never -- curl -s ${DATA_URL}/users 2>&1 | grep -v "pod.*deleted")
+echo "Initial users: $RESULT"
+echo "$RESULT" | grep -q '"result"'
+
+# Run the update script
+if [ -z $MSYSTEM ]; then
+  kubectl exec -n opal service/myopal-opal-server -- /opt/e2e/policy-repo-data/upd.sh
+else
+  kubectl exec -n opal service/myopal-opal-server -- //opt/e2e/policy-repo-data/upd.sh
+fi
+
+sleep 7
+
+# Check that users data is empty after update (OPA returns {} when data is empty)
+RESULT=$(kubectl run -n opal curl-test --image=curlimages/curl:latest --rm -i --restart=Never -- curl -s ${DATA_URL}/users 2>&1 | grep -v "pod.*deleted")
+echo "After update users: $RESULT"
+[ "$RESULT" == '{}' ]
+
+# Check that losers data is present
+RESULT=$(kubectl run -n opal curl-test --image=curlimages/curl:latest --rm -i --restart=Never -- curl -s ${DATA_URL}/losers 2>&1 | grep -v "pod.*deleted")
+echo "Losers data: $RESULT"
+echo "$RESULT" | grep -q '"result"'

--- a/charts/auth/charts/opal/test/e2e/upd.sh
+++ b/charts/auth/charts/opal/test/e2e/upd.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+cd /opt/e2e/policy-repo-working
+
+sed -i 's/users/losers/g' data.json
+
+git commit -am 'chore: update'
+git push

--- a/charts/auth/charts/opal/test/linter/test.sh
+++ b/charts/auth/charts/opal/test/linter/test.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+helm lint . --strict
+helm lint . --strict --set server=null
+helm lint . --strict --set client=null
+helm lint . --strict --set server.broadcastUri=zzz --set server.broadcastPgsql=true
+helm lint . --strict --set server.broadcastPgsql=true
+helm lint . --strict -f test/linter/values-entries.yaml

--- a/charts/auth/charts/opal/test/linter/values-entries.yaml
+++ b/charts/auth/charts/opal/test/linter/values-entries.yaml
@@ -1,0 +1,12 @@
+imageRegistry: docker.io
+imagePullSecrets: 
+  - name: my_awesome_secret
+
+server:
+  dataConfigSources:
+    config:
+      entries:
+        - url: "111"
+        - url: "222"
+
+client: null

--- a/charts/auth/charts/opal/values.yaml
+++ b/charts/auth/charts/opal/values.yaml
@@ -1,0 +1,49 @@
+broadcastReplicas: 1
+client:
+  containerSecurityContext: {}
+  extraEnv: {}
+  opaPort: 8181
+  port: 7000
+  replicas: 1
+  securityContext: {}
+image:
+  client:
+    registry: docker.io
+    repository: permitio/opal-client
+  pgsql:
+    registry: docker.io
+    repository: postgres
+    tag: alpine
+  server:
+    registry: docker.io
+    repository: permitio/opal-server
+openshift:
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    runAsNonRoot: true
+  enabled: false
+  securityContext:
+    fsGroup: 1010180000
+    runAsGroup: 1010180000
+    runAsUser: 1010180000
+postgresql:
+  containerSecurityContext: {}
+  extraEnv: {}
+  securityContext: {}
+server:
+  broadcastPgsql: true
+  broadcastUri: null
+  containerSecurityContext: {}
+  dataConfigSources:
+    config:
+      entries: []
+  extraEnv: {}
+  policyRepoClonePath: null
+  policyRepoMainBranch: null
+  policyRepoSshKey: null
+  policyRepoUrl: https://github.com/permitio/opal-example-policy-repo
+  pollingInterval: 30
+  port: 7002
+  replicas: 1
+  securityContext: {}
+  uvicornWorkers: 4


### PR DESCRIPTION
## Summary

- Vendors OPAL subchart (permitio v0.0.29) into `charts/auth/charts/opal/`
- Removes OPAL from Chart.yaml remote dependencies
- Adds `server.podAnnotations` and `client.podAnnotations` to deployment templates
- Enables Banzai Cloud Vault webhook injection on OPAL pods
- Required for `OPAL_DATA_TOPICS_BEARER_TOKEN` Vault injection (removes plaintext secret from git)
- Chart version: 0.1.9 → 0.1.10

## Test plan

- [ ] `helm template` renders Vault annotations on OPAL server pod
- [ ] Deploy to dev-aws-1, verify OPAL server starts with Vault-injected token
- [ ] Verify policy sync still works from GitLab repo