### PR TITLE
fix: pin oathkeeper to 0.60.0 — v26 broke glob matching

### DIFF
--- a/charts/auth/Chart.lock
+++ b/charts/auth/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: kratos
   repository: https://k8s.ory.sh/helm/charts
-  version: 0.61.0
+  version: 0.60.0
 - name: oathkeeper
   repository: https://k8s.ory.sh/helm/charts
-  version: 0.61.0
+  version: 0.60.0
 - name: opal
   repository: file://charts/opal
   version: 0.0.29
-digest: sha256:2884edd24c9ec7d287f79fb5fa1c4ffedda3f368e4d4d9d60861467014c5703a
-generated: "2026-04-16T10:59:04.667888654+02:00"
+digest: sha256:d5115a6dd6e6d4fa119a80c68820bf9c42812e003a177eca8d3721eafd6c464b
+generated: "2026-04-16T13:36:14.111629528+02:00"

--- a/charts/auth/Chart.yaml
+++ b/charts/auth/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: auth
 description: Complete authentication stack with Kratos, Oathkeeper, OPAL, and OPAL-static
 type: application
-version: 0.1.10
+version: 0.1.11
 appVersion: "1.0.0"
 keywords:
   - auth
@@ -23,13 +23,13 @@ icon: https://w6d.io/favicon.ico
 dependencies:
   # Kratos - Identity Management
   - name: kratos
-    version: "*"
+    version: "0.60.0"
     repository: https://k8s.ory.sh/helm/charts
     condition: kratos.enabled
 
   # Oathkeeper - API Gateway / Authorization Proxy
   - name: oathkeeper
-    version: "*"
+    version: "0.60.0"
     repository: https://k8s.ory.sh/helm/charts
     condition: oathkeeper.enabled
 


### PR DESCRIPTION
## Summary

- Pin oathkeeper to 0.60.0 (v25.4.0) — `helm dependency update` pulled 0.61.0 (v26.2.0) which broke `<{brace,group}><**>` glob matching in access rules
- Pin kratos to 0.60.0 to prevent same issue
- Chart version: 0.1.10 → 0.1.11

## Root cause

PR #140 ran `helm dependency update` which changed Chart.lock from oathkeeper 0.60.0 → 0.61.0. Oathkeeper v26 changed glob matching behavior — `<{self-service}><**>` no longer matches `/self-service/registration/api`.