### PR TITLE
feat: upgrade Kratos + Oathkeeper to v26.2.0

### DIFF
--- a/charts/auth/Chart.lock
+++ b/charts/auth/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: kratos
   repository: https://k8s.ory.sh/helm/charts
-  version: 0.60.0
+  version: 0.61.0
 - name: oathkeeper
   repository: https://k8s.ory.sh/helm/charts
-  version: 0.60.0
+  version: 0.61.0
 - name: opal
   repository: file://charts/opal
   version: 0.0.29
-digest: sha256:d5115a6dd6e6d4fa119a80c68820bf9c42812e003a177eca8d3721eafd6c464b
-generated: "2026-04-16T13:36:14.111629528+02:00"
+digest: sha256:938fc2ed9f71004b1e15e6ef0f3ea45253013cf81686675bc0622cae55b42f17
+generated: "2026-04-16T18:26:30.501276664+02:00"

--- a/charts/auth/Chart.yaml
+++ b/charts/auth/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: auth
 description: Complete authentication stack with Kratos, Oathkeeper, OPAL, and OPAL-static
 type: application
-version: 0.1.11
+version: 0.2.0
 appVersion: "1.0.0"
 keywords:
   - auth
@@ -23,13 +23,13 @@ icon: https://w6d.io/favicon.ico
 dependencies:
   # Kratos - Identity Management
   - name: kratos
-    version: "0.60.0"
+    version: "0.61.0"
     repository: https://k8s.ory.sh/helm/charts
     condition: kratos.enabled
 
   # Oathkeeper - API Gateway / Authorization Proxy
   - name: oathkeeper
-    version: "0.60.0"
+    version: "0.61.0"
     repository: https://k8s.ory.sh/helm/charts
     condition: oathkeeper.enabled
 


### PR DESCRIPTION
## Summary

- Kratos 0.60.0 → 0.61.0 (v25.4.0 → v26.2.0)
- Oathkeeper 0.60.0 → 0.61.0 (v25.4.0 → v26.2.0)
- Chart 0.1.11 → 0.2.0

Fixes: settings after recovery bug, registration style issues, identity_id migration.
Requires: access rules glob fix (brace group + wildcard separator).

## Test plan

- [ ] CI lint + install
- [ ] Kratos DB migration on RDS
- [ ] Register, verify, login, recover, settings flows
- [ ] Oathkeeper glob matching for all access rules