### PR TITLE
feat(auth): add LOGIN_UI_URL and ADMIN_UI_URL env vars to jinbe deployment (v0.4.9)

### DIFF
--- a/charts/auth/Chart.yaml
+++ b/charts/auth/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: auth
 description: Complete authentication stack with Kratos, Oathkeeper, OPAL, Jinbe, and Redis
 type: application
-version: 0.4.8
+version: 0.4.9
 appVersion: "1.0.0"
 keywords:
   - auth

--- a/charts/auth/templates/jinbe/deployment.yaml
+++ b/charts/auth/templates/jinbe/deployment.yaml
@@ -75,6 +75,10 @@ spec:
               value: {{ .Values.jinbe.env.APP_DOMAIN | default (include "auth.appDomain" .) | quote }}
             - name: API_DOMAIN
               value: {{ .Values.jinbe.env.API_DOMAIN | default (include "auth.appDomain" .) | quote }}
+            - name: LOGIN_UI_URL
+              value: {{ .Values.jinbe.env.LOGIN_UI_URL | default (printf "http://%s-kratos-login-ui:80" .Release.Name) | quote }}
+            - name: ADMIN_UI_URL
+              value: {{ .Values.jinbe.env.ADMIN_UI_URL | default (printf "http://%s-admin-ui:80" .Release.Name) | quote }}
             {{- if .Values.jinbe.env.ADMIN_EMAIL }}
             - name: ADMIN_EMAIL
               value: {{ .Values.jinbe.env.ADMIN_EMAIL | quote }}


### PR DESCRIPTION
## Summary

- Add `LOGIN_UI_URL` and `ADMIN_UI_URL` env vars to jinbe Deployment template
- Both default to `http://{release-name}-{service}:80` when not set in values
- Bump chart version to 0.4.9

## Motivation

jinbe bootstrap generates Oathkeeper access rules for login-ui and admin-ui upstreams. Previously the URLs were derived via string manipulation of other env vars (fragile). Now they can be explicitly configured via `jinbe.env.LOGIN_UI_URL` and `jinbe.env.ADMIN_UI_URL` in values, with sensible Helm-derived defaults.

## Test plan
- [x] `helm lint charts/auth --set jinbe.env.ENCRYPTION_KEY=aaaabbbbccccddddeeeeffffgggghhhh --set oathkeeper.enabled=false --set kratos.enabled=false --set opal.enabled=false --set redis.enabled=false`
- [x] Verify jinbe deployment renders LOGIN_UI_URL and ADMIN_UI_URL env vars