### PR TITLE
feat(auth): chart 0.5.0 — bootstrap Job, env helpers, AUTH_DOMAIN, NetworkPolicy

### DIFF
--- a/charts/auth/Chart.yaml
+++ b/charts/auth/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: auth
 description: Complete authentication stack with Kratos, Oathkeeper, OPAL, Jinbe, and Redis
 type: application
-version: 0.4.9
+version: 0.5.0
 appVersion: "1.0.0"
 keywords:
   - auth

--- a/charts/auth/Chart.yaml
+++ b/charts/auth/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: auth
 description: Complete authentication stack with Kratos, Oathkeeper, OPAL, Jinbe, and Redis
 type: application
-version: 0.4.8
+version: 0.4.9
 appVersion: "1.0.0"
 keywords:
   - auth

--- a/charts/auth/templates/NOTES.txt
+++ b/charts/auth/templates/NOTES.txt
@@ -20,3 +20,37 @@ Endpoints:
 
 First visit: Register at https://{{ include "auth.authDomain" . }}/register
 First user gets super_admin access automatically.
+
+──────────────────────────────────────────────────────────────────────
+First-time setup checklist
+──────────────────────────────────────────────────────────────────────
+
+1. Database (Kratos)
+   Default DSN expects the bundled postgresqlSimple Service:
+     postgresql://kratos:kratos@auth-postgresql:5432/kratos
+   If your release name is NOT "auth", override:
+     --set kratos.kratos.config.dsn=postgresql://kratos:kratos@{{ .Release.Name }}-postgresql:5432/kratos?sslmode=disable
+
+   Alternative for dev / single-instance: SQLite (no Postgres pod):
+     --set kratos.kratos.config.dsn='sqlite:///var/lib/kratos/kratos.sqlite?_fk=true&mode=rwc'
+     --set postgresqlSimple.enabled=false
+   (mount a PVC at /var/lib/kratos via kratos.deployment.extraVolumes/extraVolumeMounts)
+   See https://www.ory.sh/docs/hydra/self-hosted/dependencies-environment#sqlite
+
+2. Replace placeholder secrets BEFORE production
+   The defaults under kratos.kratos.config.secrets are NOT secure.
+   Override default[*]/cookie[*] (≥16 chars) and cipher[*] (exactly 32 chars).
+
+3. Set jinbe.env.ENCRYPTION_KEY (≥32 chars)
+   --set jinbe.env.ENCRYPTION_KEY="<random-32-char-string>"
+
+4. Set domains
+   --set global.authDomain=auth.your.com
+   --set global.appDomain=app.your.com
+
+5. Set initial admin (only required on first install — marker absent)
+   --set jinbe.env.ADMIN_EMAIL=admin@your.com
+   --set jinbe.env.ADMIN_PASSWORD="<≥12-char-password>"
+
+The Bootstrap Job (auth-jinbe-bootstrap) runs once per Helm install/upgrade
+and is a no-op on subsequent runs (Redis marker rbac:bootstrap:state).

--- a/charts/auth/templates/_helpers.tpl
+++ b/charts/auth/templates/_helpers.tpl
@@ -233,8 +233,6 @@ API server needs but the Bootstrap Job does NOT. Included by deployment.yaml.
   value: {{ .Values.jinbe.env.OPAL_SERVER_URL | default (printf "http://%s-opal-server:7002" .Release.Name) | quote }}
 - name: OPA_DATA_URL
   value: {{ .Values.jinbe.env.OPA_DATA_URL | default (printf "http://%s-opal-client:8181" .Release.Name) | quote }}
-- name: INTERNAL_TRUSTED_HOSTS
-  value: {{ printf "%s:%s,%s" (include "auth.jinbe.fullname" .) (.Values.jinbe.service.port | toString) (include "auth.jinbe.fullname" .) | quote }}
 - name: CORS_ORIGIN
   value: {{ .Values.jinbe.env.CORS_ORIGIN | default (printf "https://%s,https://%s" (include "auth.appDomain" .) (include "auth.authDomain" .)) | quote }}
 - name: ENABLE_SWAGGER

--- a/charts/auth/templates/_helpers.tpl
+++ b/charts/auth/templates/_helpers.tpl
@@ -149,6 +149,103 @@ app.kubernetes.io/component: jinbe
 {{- end }}
 
 {{/*
+Jinbe pod annotations — user-provided values + (when global.vault.enabled) the
+banzai vault injector annotations. Used by both the Deployment and the
+post-install Bootstrap Job so they share an identical Vault scope.
+*/}}
+{{- define "auth.jinbe.podAnnotations" -}}
+{{- with .Values.jinbe.podAnnotations -}}
+{{- toYaml . }}
+{{- end }}
+{{- end }}
+
+{{/*
+Jinbe environment variables — runtime + bootstrap-required.
+Included verbatim by templates/jinbe/deployment.yaml and
+templates/jinbe/bootstrap-job.yaml so both pods share a single source of truth.
+
+Bootstrap-only env (ADMIN_EMAIL/PASSWORD/NAME) is gated by
+`if .Values.jinbe.env.ADMIN_*` — only emitted when explicitly set.
+*/}}
+{{- define "auth.jinbe.env" -}}
+- name: NODE_ENV
+  value: {{ .Values.jinbe.env.NODE_ENV | default "production" | quote }}
+- name: APP_NAME
+  value: {{ .Values.jinbe.env.APP_NAME | default "jinbe" | quote }}
+- name: LOG_LEVEL
+  value: {{ .Values.jinbe.env.LOG_LEVEL | default "info" | quote }}
+- name: RELEASE_NAME
+  value: {{ .Release.Name | quote }}
+- name: APP_VERSION
+  value: {{ .Values.jinbe.image.tag | default .Chart.AppVersion | quote }}
+- name: COMMIT_SHA
+  value: {{ .Values.jinbe.env.COMMIT_SHA | default (.Values.jinbe.image.tag | default .Chart.AppVersion) | quote }}
+- name: REDIS_URL
+  value: {{ .Values.jinbe.env.REDIS_URL | default (printf "redis://%s-redis-master:6379" .Release.Name) | quote }}
+- name: KRATOS_PUBLIC_URL
+  value: {{ .Values.jinbe.env.KRATOS_PUBLIC_URL | default (printf "http://%s-kratos-public:80" .Release.Name) | quote }}
+- name: KRATOS_ADMIN_URL
+  value: {{ .Values.jinbe.env.KRATOS_ADMIN_URL | default (printf "http://%s-kratos-admin:80" .Release.Name) | quote }}
+- name: JINBE_INTERNAL_URL
+  value: {{ .Values.jinbe.env.JINBE_INTERNAL_URL | default (printf "http://%s:%s" (include "auth.jinbe.fullname" .) (.Values.jinbe.service.port | toString)) | quote }}
+- name: AUTH_DOMAIN
+  value: {{ .Values.jinbe.env.AUTH_DOMAIN | default (include "auth.authDomain" .) | quote }}
+- name: APP_DOMAIN
+  value: {{ .Values.jinbe.env.APP_DOMAIN | default (include "auth.appDomain" .) | quote }}
+- name: API_DOMAIN
+  value: {{ .Values.jinbe.env.API_DOMAIN | default (include "auth.appDomain" .) | quote }}
+- name: LOGIN_UI_URL
+  value: {{ .Values.jinbe.env.LOGIN_UI_URL | default (printf "http://%s-kratos-login-ui:80" .Release.Name) | quote }}
+- name: ADMIN_UI_URL
+  value: {{ .Values.jinbe.env.ADMIN_UI_URL | default (printf "http://%s-admin-ui:80" .Release.Name) | quote }}
+- name: ENCRYPTION_KEY
+  value: {{ required "jinbe.env.ENCRYPTION_KEY is required" .Values.jinbe.env.ENCRYPTION_KEY | quote }}
+{{- if .Values.jinbe.env.ADMIN_EMAIL }}
+- name: ADMIN_EMAIL
+  value: {{ .Values.jinbe.env.ADMIN_EMAIL | quote }}
+{{- end }}
+{{- if .Values.jinbe.env.ADMIN_PASSWORD }}
+- name: ADMIN_PASSWORD
+  value: {{ .Values.jinbe.env.ADMIN_PASSWORD | quote }}
+{{- end }}
+{{- if .Values.jinbe.env.ADMIN_NAME }}
+- name: ADMIN_NAME
+  value: {{ .Values.jinbe.env.ADMIN_NAME | quote }}
+{{- end }}
+{{- range $name, $value := .Values.jinbe.extraEnv }}
+- name: {{ $name }}
+  value: {{ $value | quote }}
+{{- end }}
+{{- end }}
+
+{{/*
+Jinbe runtime-only env — additions on top of auth.jinbe.env that the
+API server needs but the Bootstrap Job does NOT. Included by deployment.yaml.
+*/}}
+{{- define "auth.jinbe.envRuntimeOnly" -}}
+- name: PORT
+  value: "3000"
+- name: HOST
+  value: "0.0.0.0"
+- name: OPA_URL
+  value: {{ .Values.jinbe.env.OPA_URL | default (printf "http://%s-opal-client:8181" .Release.Name) | quote }}
+- name: OPAL_SERVER_URL
+  value: {{ .Values.jinbe.env.OPAL_SERVER_URL | default (printf "http://%s-opal-server:7002" .Release.Name) | quote }}
+- name: OPA_DATA_URL
+  value: {{ .Values.jinbe.env.OPA_DATA_URL | default (printf "http://%s-opal-client:8181" .Release.Name) | quote }}
+- name: INTERNAL_TRUSTED_HOSTS
+  value: {{ printf "%s:%s,%s" (include "auth.jinbe.fullname" .) (.Values.jinbe.service.port | toString) (include "auth.jinbe.fullname" .) | quote }}
+- name: CORS_ORIGIN
+  value: {{ .Values.jinbe.env.CORS_ORIGIN | default (printf "https://%s,https://%s" (include "auth.appDomain" .) (include "auth.authDomain" .)) | quote }}
+- name: ENABLE_SWAGGER
+  value: {{ .Values.jinbe.env.ENABLE_SWAGGER | default "false" | quote }}
+{{- if .Values.jinbe.env.DATABASE_URL }}
+- name: DATABASE_URL
+  value: {{ .Values.jinbe.env.DATABASE_URL | quote }}
+{{- end }}
+{{- end }}
+
+{{/*
 Auth domain
 */}}
 {{- define "auth.authDomain" -}}

--- a/charts/auth/templates/admin-ui/deployment.yaml
+++ b/charts/auth/templates/admin-ui/deployment.yaml
@@ -37,6 +37,10 @@ spec:
           env:
             - name: API_BASE
               value: {{ .Values.adminUi.env.API_BASE | default "" | quote }}
+            # AUTH_DOMAIN is substituted into kuma's index.html at container start
+            # (envsubst → window.__AUTH_DOMAIN__). Drives the 401 redirect target.
+            - name: AUTH_DOMAIN
+              value: {{ .Values.adminUi.env.AUTH_DOMAIN | default (include "auth.authDomain" .) | quote }}
             {{- range $name, $value := .Values.adminUi.extraEnv }}
             - name: {{ $name }}
               value: {{ $value | quote }}

--- a/charts/auth/templates/jinbe/bootstrap-job.yaml
+++ b/charts/auth/templates/jinbe/bootstrap-job.yaml
@@ -1,0 +1,59 @@
+{{- if and .Values.jinbe.enabled .Values.jinbe.bootstrap.enabled }}
+{{/*
+  Jinbe bootstrap Job — runs `node dist/cli/bootstrap.js` once per Helm
+  install/upgrade.
+
+  Idempotent: the CLI checks the marker key `rbac:bootstrap:state` in Redis
+  and exits 0 immediately if already initialized.
+
+  Stable name (no .Release.Revision) — under ArgoCD, .Release.Revision is
+  always 1 because ArgoCD calls `helm template`, not `helm upgrade`. Using
+  `before-hook-creation` lets Helm delete the prior Job (and pod) right
+  before creating a new one, so each deploy gets a fresh run.
+
+  Kept across success/failure (no `hook-succeeded` policy, no
+  `ttlSecondsAfterFinished`) so logs are inspectable until the next deploy.
+
+  Dual annotations: helm.sh/* for `helm install/upgrade`, argocd.argoproj.io/*
+  for ArgoCD's hook lifecycle. Both are honored in their respective tools.
+*/}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "auth.jinbe.fullname" . }}-bootstrap
+  labels:
+    {{- include "auth.jinbe.labels" . | nindent 4 }}
+    app.kubernetes.io/component: jinbe-bootstrap
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "5"
+    helm.sh/hook-delete-policy: before-hook-creation
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+spec:
+  backoffLimit: 0
+  activeDeadlineSeconds: {{ .Values.jinbe.bootstrap.activeDeadlineSeconds | default 600 }}
+  template:
+    metadata:
+      labels:
+        {{- include "auth.jinbe.labels" . | nindent 8 }}
+        app.kubernetes.io/component: jinbe-bootstrap
+      annotations:
+        {{- include "auth.jinbe.podAnnotations" . | nindent 8 }}
+    spec:
+      restartPolicy: OnFailure
+      {{- if and .Values.jinbe.enabled .Values.jinbe.serviceAccount.create }}
+      serviceAccountName: {{ include "auth.jinbe.serviceAccountName" . }}
+      {{- end }}
+      containers:
+        - name: bootstrap
+          image: "{{ .Values.jinbe.image.repository }}:{{ .Values.jinbe.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.jinbe.image.pullPolicy }}
+          command: ["node", "dist/cli/bootstrap.js"]
+          env:
+            {{- include "auth.jinbe.env" . | nindent 12 }}
+          {{- with .Values.jinbe.bootstrap.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+{{- end }}

--- a/charts/auth/templates/jinbe/deployment.yaml
+++ b/charts/auth/templates/jinbe/deployment.yaml
@@ -75,6 +75,10 @@ spec:
               value: {{ .Values.jinbe.env.APP_DOMAIN | default (include "auth.appDomain" .) | quote }}
             - name: API_DOMAIN
               value: {{ .Values.jinbe.env.API_DOMAIN | default (include "auth.appDomain" .) | quote }}
+            - name: LOGIN_UI_URL
+              value: {{ .Values.jinbe.env.LOGIN_UI_URL | default (printf "http://%s-kratos-login-ui:80" .Release.Name) | quote }}
+            - name: ADMIN_UI_URL
+              value: {{ .Values.jinbe.env.ADMIN_UI_URL | default (printf "http://%s-admin-ui:80" .Release.Name) | quote }}
             {{- if .Values.jinbe.env.ADMIN_EMAIL }}
             - name: ADMIN_EMAIL
               value: {{ .Values.jinbe.env.ADMIN_EMAIL | quote }}

--- a/charts/auth/templates/jinbe/deployment.yaml
+++ b/charts/auth/templates/jinbe/deployment.yaml
@@ -14,10 +14,8 @@ spec:
     metadata:
       labels:
         {{- include "auth.jinbe.labels" . | nindent 8 }}
-      {{- with .Values.jinbe.podAnnotations }}
       annotations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- include "auth.jinbe.podAnnotations" . | nindent 8 }}
     spec:
       {{- if and .Values.jinbe.enabled .Values.jinbe.serviceAccount.create }}
       serviceAccountName: {{ include "auth.jinbe.serviceAccountName" . }}
@@ -31,70 +29,14 @@ spec:
               containerPort: 3000
               protocol: TCP
           env:
-            - name: NODE_ENV
-              value: {{ .Values.jinbe.env.NODE_ENV | default "production" | quote }}
-            - name: PORT
-              value: "3000"
-            - name: HOST
-              value: "0.0.0.0"
-            - name: APP_NAME
-              value: {{ .Values.jinbe.env.APP_NAME | default "jinbe" | quote }}
-            - name: REDIS_URL
-              value: {{ .Values.jinbe.env.REDIS_URL | default (printf "redis://%s-redis-master:6379" .Release.Name) | quote }}
-            - name: KRATOS_PUBLIC_URL
-              value: {{ .Values.jinbe.env.KRATOS_PUBLIC_URL | default (printf "http://%s-kratos-public:80" .Release.Name) | quote }}
-            - name: KRATOS_ADMIN_URL
-              value: {{ .Values.jinbe.env.KRATOS_ADMIN_URL | default (printf "http://%s-kratos-admin:80" .Release.Name) | quote }}
-            - name: OPA_URL
-              value: {{ .Values.jinbe.env.OPA_URL | default (printf "http://%s-opal-client:8181" .Release.Name) | quote }}
-            - name: OPAL_SERVER_URL
-              value: {{ .Values.jinbe.env.OPAL_SERVER_URL | default (printf "http://%s-opal-server:7002" .Release.Name) | quote }}
-            - name: JINBE_INTERNAL_URL
-              value: {{ .Values.jinbe.env.JINBE_INTERNAL_URL | default (printf "http://%s:%s" (include "auth.jinbe.fullname" .) (.Values.jinbe.service.port | toString)) | quote }}
-            - name: INTERNAL_TRUSTED_HOSTS
-              value: {{ printf "%s:%s,%s" (include "auth.jinbe.fullname" .) (.Values.jinbe.service.port | toString) (include "auth.jinbe.fullname" .) | quote }}
-            - name: OPAL_RBAC_BRANCH
-              value: {{ .Values.jinbe.env.OPAL_RBAC_BRANCH | default "develop" | quote }}
-            - name: OPA_DATA_URL
-              value: {{ .Values.jinbe.env.OPA_DATA_URL | default (printf "http://%s-opal-client:8181" .Release.Name) | quote }}
-            - name: CORS_ORIGIN
-              value: {{ .Values.jinbe.env.CORS_ORIGIN | default (printf "https://%s,https://%s" (include "auth.appDomain" .) (include "auth.authDomain" .)) | quote }}
-            - name: ENCRYPTION_KEY
-              value: {{ required "jinbe.env.ENCRYPTION_KEY is required" .Values.jinbe.env.ENCRYPTION_KEY | quote }}
-            - name: ENABLE_SWAGGER
-              value: {{ .Values.jinbe.env.ENABLE_SWAGGER | default "false" | quote }}
-            - name: LOG_LEVEL
-              value: {{ .Values.jinbe.env.LOG_LEVEL | default "info" | quote }}
-            {{- if .Values.jinbe.env.DATABASE_URL }}
-            - name: DATABASE_URL
-              value: {{ .Values.jinbe.env.DATABASE_URL | quote }}
-            {{- end }}
-            - name: AUTH_DOMAIN
-              value: {{ .Values.jinbe.env.AUTH_DOMAIN | default (include "auth.authDomain" .) | quote }}
-            - name: APP_DOMAIN
-              value: {{ .Values.jinbe.env.APP_DOMAIN | default (include "auth.appDomain" .) | quote }}
-            - name: API_DOMAIN
-              value: {{ .Values.jinbe.env.API_DOMAIN | default (include "auth.appDomain" .) | quote }}
-            - name: LOGIN_UI_URL
-              value: {{ .Values.jinbe.env.LOGIN_UI_URL | default (printf "http://%s-kratos-login-ui:80" .Release.Name) | quote }}
-            - name: ADMIN_UI_URL
-              value: {{ .Values.jinbe.env.ADMIN_UI_URL | default (printf "http://%s-admin-ui:80" .Release.Name) | quote }}
-            {{- if .Values.jinbe.env.ADMIN_EMAIL }}
-            - name: ADMIN_EMAIL
-              value: {{ .Values.jinbe.env.ADMIN_EMAIL | quote }}
-            {{- end }}
-            {{- if .Values.jinbe.env.ADMIN_PASSWORD }}
-            - name: ADMIN_PASSWORD
-              value: {{ .Values.jinbe.env.ADMIN_PASSWORD | quote }}
-            {{- end }}
-            {{- if .Values.jinbe.env.ADMIN_NAME }}
-            - name: ADMIN_NAME
-              value: {{ .Values.jinbe.env.ADMIN_NAME | quote }}
-            {{- end }}
-            {{- range $name, $value := .Values.jinbe.extraEnv }}
-            - name: {{ $name }}
-              value: {{ $value | quote }}
-            {{- end }}
+            {{- include "auth.jinbe.env" . | nindent 12 }}
+            {{- include "auth.jinbe.envRuntimeOnly" . | nindent 12 }}
+          startupProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            periodSeconds: 5
+            failureThreshold: 72
           readinessProbe:
             httpGet:
               path: /api/health

--- a/charts/auth/templates/jinbe/networkpolicy.yaml
+++ b/charts/auth/templates/jinbe/networkpolicy.yaml
@@ -1,0 +1,63 @@
+{{- if and .Values.jinbe.enabled .Values.jinbe.networkPolicy.enabled }}
+{{/*
+  NetworkPolicy — restrict ingress to the Jinbe Service so only intended
+  callers can reach it. Without this, any pod in the namespace can hit
+  jinbe directly with arbitrary headers (the proxy-header fallback in
+  identity-extractor was removed, but defence in depth still matters —
+  RBAC mutation endpoints, OPAL data sources, etc. should not be reachable
+  from random workloads).
+
+  Allowed ingress:
+    - Oathkeeper proxy pods         (production traffic on port 8080)
+    - OPAL server pods              (datasource pulls)
+    - OPAL client pods              (data fetch)
+    - kubelet / probes from any pod IP on the node (use a wide rule —
+      probes don't carry pod labels)
+    - Optionally extra peers via .Values.jinbe.networkPolicy.extraIngress
+
+  All egress is allowed (jinbe needs Redis, Kratos, OPAL, OPA, GitHub, etc.).
+*/}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "auth.jinbe.fullname" . }}
+  labels:
+    {{- include "auth.jinbe.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "auth.jinbe.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        # Oathkeeper proxy + api pods (kratos chart standard labels)
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: oathkeeper
+              app.kubernetes.io/instance: {{ .Release.Name }}
+        # OPAL server (calls /api/admin/rbac/opal-datasource etc.)
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: opal-server
+              app.kubernetes.io/instance: {{ .Release.Name }}
+        # OPAL client (calls /api/admin/rbac/opal/* and /bindings)
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: opal-client
+              app.kubernetes.io/instance: {{ .Release.Name }}
+        # Admin UI (kuma) — proxies API calls to jinbe via oathkeeper, but
+        # keep direct path open for in-namespace SPA backend calls.
+        {{- if .Values.adminUi.enabled }}
+        - podSelector:
+            matchLabels:
+              {{- include "auth.selectorLabels" . | nindent 14 }}
+              app.kubernetes.io/component: admin-ui
+        {{- end }}
+        {{- with .Values.jinbe.networkPolicy.extraIngress }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.jinbe.service.port }}
+{{- end }}

--- a/charts/auth/templates/kratos-login-ui/deployment.yaml
+++ b/charts/auth/templates/kratos-login-ui/deployment.yaml
@@ -40,45 +40,46 @@ spec:
             - name: http
               containerPort: {{ .Values.kratosLoginUi.service.targetPort }}
               protocol: TCP
+          # Login UI reads runtime config via next-runtime-env (PublicEnvScript).
+          # All client-visible config MUST use NEXT_PUBLIC_ prefix to be injected
+          # at request time. KRATOS_PUBLIC_URL stays server-only (no prefix).
           env:
-            - name: APP_NAME
+            - name: NEXT_PUBLIC_APP_NAME
               value: {{ .Values.kratosLoginUi.branding.appName | quote }}
-            - name: LOGO_URL
+            - name: NEXT_PUBLIC_LOGO_URL
               value: {{ .Values.kratosLoginUi.branding.logoUrl | quote }}
-            - name: FAVICON_URL
+            - name: NEXT_PUBLIC_FAVICON_URL
               value: {{ .Values.kratosLoginUi.branding.faviconUrl | quote }}
-            - name: THEME_PRIMARY_COLOR
+            - name: NEXT_PUBLIC_THEME_PRIMARY_COLOR
               value: {{ .Values.kratosLoginUi.theme.primaryColor | quote }}
-            - name: THEME_DARK_MODE
+            - name: NEXT_PUBLIC_THEME_DARK_MODE
               value: {{ .Values.kratosLoginUi.theme.darkMode | quote }}
-            - name: THEME_BACKGROUND_COLOR
+            - name: NEXT_PUBLIC_THEME_BACKGROUND_COLOR
               value: {{ .Values.kratosLoginUi.theme.backgroundColor | quote }}
-            - name: KRATOS_BROWSER_URL
-              value: {{ .Values.kratosLoginUi.kratos.browserUrl | quote }}
             - name: NEXT_PUBLIC_KRATOS_BROWSER_URL
               value: {{ .Values.kratosLoginUi.kratos.browserUrl | quote }}
             - name: KRATOS_PUBLIC_URL
               value: {{ .Values.kratosLoginUi.kratos.publicUrl | default (printf "http://%s-kratos-public:80" .Release.Name) | quote }}
-            - name: DEFAULT_RETURN_URL
+            - name: NEXT_PUBLIC_DEFAULT_RETURN_URL
               value: {{ .Values.kratosLoginUi.redirects.defaultReturnUrl | quote }}
-            - name: ALLOWED_RETURN_URLS
+            - name: NEXT_PUBLIC_ALLOWED_RETURN_URLS
               value: {{ .Values.kratosLoginUi.redirects.allowedReturnUrls | quote }}
-            - name: LOGIN_TITLE
+            - name: NEXT_PUBLIC_LOGIN_TITLE
               value: {{ .Values.kratosLoginUi.texts.loginTitle | quote }}
-            - name: LOGIN_SUBTITLE
+            - name: NEXT_PUBLIC_LOGIN_SUBTITLE
               value: {{ .Values.kratosLoginUi.texts.loginSubtitle | quote }}
-            - name: REGISTER_TITLE
+            - name: NEXT_PUBLIC_REGISTER_TITLE
               value: {{ .Values.kratosLoginUi.texts.registerTitle | quote }}
-            - name: REGISTER_SUBTITLE
+            - name: NEXT_PUBLIC_REGISTER_SUBTITLE
               value: {{ .Values.kratosLoginUi.texts.registerSubtitle | quote }}
-            - name: RECOVERY_TITLE
+            - name: NEXT_PUBLIC_RECOVERY_TITLE
               value: {{ .Values.kratosLoginUi.texts.recoveryTitle | quote }}
-            - name: RECOVERY_SUBTITLE
+            - name: NEXT_PUBLIC_RECOVERY_SUBTITLE
               value: {{ .Values.kratosLoginUi.texts.recoverySubtitle | quote }}
-            - name: FOOTER_TEXT
+            - name: NEXT_PUBLIC_FOOTER_TEXT
               value: {{ .Values.kratosLoginUi.footer.text | quote }}
             {{- if .Values.kratosLoginUi.footer.links }}
-            - name: FOOTER_LINKS
+            - name: NEXT_PUBLIC_FOOTER_LINKS
               value: {{ .Values.kratosLoginUi.footer.links | toJson | quote }}
             {{- end }}
           livenessProbe:

--- a/charts/auth/values.yaml
+++ b/charts/auth/values.yaml
@@ -46,16 +46,44 @@ kratos:
   kratos:
     automountServiceAccountToken: true
     config:
-      # Database connection — override in env overlay or use Vault
-      # Default uses bundled simple postgresql (auto-computed at deploy time via --set)
-      dsn: postgresql://kratos:kratos@RELEASE-auth-postgresql:5432/kratos?sslmode=disable
+      # ─── Database (DSN) ───────────────────────────────────────────────────
+      # The chart bundles a simple postgresql StatefulSet (postgresqlSimple)
+      # whose Service is `<release>-postgresql:5432`. The default DSN below
+      # assumes you install with `helm install auth ./auth`, producing service
+      # `auth-postgresql`. Override `kratos.kratos.config.dsn` if your release
+      # name differs OR you point at an external DB.
+      #
+      # Plug-and-play options:
+      #   - Bundled simple postgres (default):
+      #       dsn: postgresql://kratos:kratos@auth-postgresql:5432/kratos?sslmode=disable
+      #
+      #   - SQLite (single-instance, dev or low-traffic; data persists in PVC):
+      #       dsn: sqlite:///var/lib/kratos/kratos.sqlite?_fk=true&mode=rwc
+      #     (also disable postgresqlSimple, mount a PVC at /var/lib/kratos
+      #      via kratos.deployment.extraVolumes/extraVolumeMounts)
+      #     Reference: https://www.ory.sh/docs/hydra/self-hosted/dependencies-environment#sqlite
+      #
+      #   - External Postgres / RDS / Cloud SQL:
+      #       dsn: postgresql://USER:PASS@HOST:5432/DB?sslmode=require
+      #
+      #   - In-memory (state lost on pod restart — testing only):
+      #       dsn: memory
+      dsn: postgresql://kratos:kratos@auth-postgresql:5432/kratos?sslmode=disable
+
+      # ─── Cryptographic secrets ────────────────────────────────────────────
+      # Ory schema constraints:
+      #   default[*]  — min 16 chars
+      #   cookie[*]   — min 16 chars (used to sign session cookies)
+      #   cipher[*]   — exactly 32 chars (XChaCha20-Poly1305 key)
+      # PROD: rotate via vault and pass via Vault sidecar / external secrets.
+      # Examples below are deterministic placeholders, NOT for production use.
       secrets:
         default:
-          - changeme-default-secret
+          - changeme-default-secret-16chars
         cookie:
-          - changeme-cookie-secret
+          - changeme-cookie-secret-16chars0
         cipher:
-          - changeme-this-cipher-secret-32ch
+          - changeme-this-cipher-secret-32cc
       identity:
         default_schema_id: default
         schemas:
@@ -116,8 +144,16 @@ kratos:
           iterations: 2
           salt_length: 16
           key_length: 16
+    # ─── Database migration ───────────────────────────────────────────────
+    # initContainer runs migration inside the Kratos pod before the main
+    # container starts, so it waits for Postgres readiness through normal
+    # Pod lifecycle. The alternative (`type: job`) creates a Helm pre-install
+    # hook that runs BEFORE chart resources, deadlocking fresh installs that
+    # bundle their own postgres (hook waits for DB, DB hasn't been deployed
+    # yet). InitContainer is idempotent and safe for already-migrated DBs.
     automigration:
       enabled: true
+      type: initContainer
 
     # Example identity schemas - customize for your use case
     identitySchemas:
@@ -201,9 +237,13 @@ oathkeeper:
         header:
           enabled: true
           config:
+            # Oathkeeper runtime templates — escaped so helm's tpl pass leaves
+            # them intact for oathkeeper to evaluate per-request. The email
+            # template is nil-safe so requests reaching this rule via the
+            # noop fallback authenticator (no session) don't crash.
             headers:
-              x-user-id: '{{ print .Subject }}'
-              x-user-email: '{{ index .Extra.identity.traits "email" }}'
+              x-user-id: '{{ "{{" }} print .Subject {{ "}}" }}'
+              x-user-email: '{{ "{{" }} if .Extra.identity {{ "}}" }}{{ "{{" }} index .Extra.identity.traits "email" {{ "}}" }}{{ "{{" }} end {{ "}}" }}'
       errors:
         fallback: [redirect, json]
         handlers:
@@ -254,7 +294,10 @@ opal:
     policyRepoMainBranch: "main"
     pollingInterval: 30
     broadcastPgsql: false
-    broadcastUri: ""  # Auto: redis://{release}-redis-master:6379 (set in env overlay)
+    broadcastUri: ""  # Required only when uvicornWorkers > 1 — redis://<release>-redis-master:6379
+    # Single worker → no need for inter-worker broadcast bus.
+    # Increase + set broadcastUri when scaling.
+    uvicornWorkers: 1
     replicas: 1
     # OPAL fetches RBAC data from Jinbe (external data source)
     dataConfigSources:
@@ -280,9 +323,15 @@ jinbe:
     create: true
     name: ""
     token: false
+  # Jinbe image — REQUIRED override unless your cluster has a pull secret for
+  # the W6D registry. The default below is private; a public release (e.g.
+  # ghcr.io/w6d-io/jinbe:vX.Y.Z) will be wired in once published.
+  # Override examples:
+  #   --set jinbe.image.repository=<your-registry>/jinbe
+  #   --set jinbe.image.tag=latest
   image:
-    repository: ghcr.io/w6d-io/jinbe-api
-    tag: ""
+    repository: ghcr.io/w6d-io/jinbe
+    tag: ""              # empty → falls back to .Chart.AppVersion
     pullPolicy: IfNotPresent
 
   service:
@@ -301,7 +350,6 @@ jinbe:
     # OPA_URL: auto-computed as http://<release>-opal-client:8181
     # OPAL_SERVER_URL: auto-computed as http://<release>-opal-server:7002
     # JINBE_INTERNAL_URL: auto-computed as http://<release>-jinbe:8080
-    # OPAL_RBAC_BRANCH: develop
     # OPA_DATA_URL: auto-computed as http://<release>-opal-client:8181
     # CORS_ORIGIN: auto-computed from global.appDomain and global.authDomain
     # ENABLE_SWAGGER: "false"
@@ -324,6 +372,19 @@ jinbe:
     limits:
       cpu: 500m
       memory: 512Mi
+
+  # NetworkPolicy — restrict who can reach jinbe Service. Defence in depth:
+  # jinbe authenticates exclusively via Kratos session cookie now (the proxy-
+  # header fallback was removed), but limiting peer connectivity prevents
+  # rogue/compromised pods in the namespace from hitting admin endpoints
+  # without first going through oathkeeper. Allowed peers by default:
+  # oathkeeper, opal-server, opal-client, admin-ui (when enabled).
+  # Set `enabled: false` if your CNI doesn't support NetworkPolicy.
+  networkPolicy:
+    enabled: true
+    # extraIngress: list of NetworkPolicyPeer entries appended to the rule
+    # (e.g. additional namespaceSelector / podSelector). Yaml-merge friendly.
+    extraIngress: []
 
   # Bootstrap Job — runs `node dist/cli/bootstrap.js` as a Helm post-install /
   # post-upgrade hook. Idempotent: skipped via Redis marker on subsequent runs.
@@ -387,7 +448,12 @@ opaAuthzProxy:
 # Kratos Login UI
 # =============================================================================
 kratosLoginUi:
-  enabled: true
+  # Disabled by default — the image is not published to a public registry.
+  # To enable, set `kratosLoginUi.enabled: true` and provide a working image
+  # repository (W6D internal: 095...ecr.../infra/frontend/kratos-login-ui/w6d).
+  # The Oathkeeper rule `selfservice-ui` upstream points at this Service —
+  # auth/registration UI flows require this enabled.
+  enabled: false
   replicaCount: 1
 
   image:

--- a/charts/auth/values.yaml
+++ b/charts/auth/values.yaml
@@ -325,6 +325,21 @@ jinbe:
       cpu: 500m
       memory: 512Mi
 
+  # Bootstrap Job — runs `node dist/cli/bootstrap.js` as a Helm post-install /
+  # post-upgrade hook. Idempotent: skipped via Redis marker on subsequent runs.
+  # The Job uses the same image, ServiceAccount, and Vault podAnnotations as
+  # the API Deployment.
+  bootstrap:
+    enabled: true
+    activeDeadlineSeconds: 600
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        cpu: 200m
+        memory: 256Mi
+
 # =============================================================================
 # Redis - Data Store (Bitnami)
 # =============================================================================


### PR DESCRIPTION
## Summary

- Chart bump 0.4.9 → 0.5.0
- Jinbe bootstrap Job (`templates/jinbe/bootstrap-job.yaml`) — Helm post-install Job, idempotent via Redis marker + SETNX lock + canonical-JSON sha256 hash drift detection
- Jinbe env helpers (`auth.jinbe.env`, `auth.jinbe.envRuntimeOnly`) — single source of truth shared by Deployment + bootstrap Job
- Kuma `AUTH_DOMAIN` env on admin-ui Deployment — substituted into `index.html` at container start, drives `window.__AUTH_DOMAIN__` for 401 redirect + account-settings link
- Plug-and-play defaults — auth-postgresql DSN, kratos automigration as initContainer, OPAL workers=1, jinbe.image.repository fix, kratosLoginUi disabled by default
- Jinbe NetworkPolicy — restricts ingress to oathkeeper, opal-server, opal-client, admin-ui

## Notes

- Required for kuma v2.3.0 — without `AUTH_DOMAIN` env, sidebar avatar click falls back to in-app settings instead of redirecting to auth domain
- Bootstrap Job depends on jinbe v0.3.0 image (CLI binary `bootstrap.js`) — image needs publish before chart sync
- Validated end-to-end on `w6d-oauth-test` namespace pre-merge

## Test plan

- [ ] `ct lint` passes (chart version bumped)
- [ ] ArgoCD diff against dev-aws-1 shows AUTH_DOMAIN env on admin-ui pod
- [ ] After sync: kuma sidebar avatar click → auth.dev.w6d.io/settings
- [ ] Bootstrap Job runs once on install, gated by Redis marker on subsequent installs