### PR TITLE
fix(auth): bootstrap Job ordering via sync-wave (chart 0.5.1)

### DIFF
--- a/charts/auth/Chart.yaml
+++ b/charts/auth/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: auth
 description: Complete authentication stack with Kratos, Oathkeeper, OPAL, Jinbe, and Redis
 type: application
-version: 0.5.0
+version: 0.5.1
 appVersion: "1.0.0"
 keywords:
   - auth

--- a/charts/auth/templates/jinbe/bootstrap-job.yaml
+++ b/charts/auth/templates/jinbe/bootstrap-job.yaml
@@ -16,6 +16,12 @@
 
   Dual annotations: helm.sh/* for `helm install/upgrade`, argocd.argoproj.io/*
   for ArgoCD's hook lifecycle. Both are honored in their respective tools.
+
+  ArgoCD ordering: `hook: Sync` runs as part of the main Sync phase (not
+  post-Sync) with `sync-wave: "5"`, so it executes BEFORE the jinbe
+  Deployment (sync-wave: "10"). Required because jinbe gates startup on the
+  bootstrap marker — if the Job ran post-Sync, jinbe would never become
+  Ready and Sync would deadlock.
 */}}
 apiVersion: batch/v1
 kind: Job
@@ -28,8 +34,9 @@ metadata:
     helm.sh/hook: post-install,post-upgrade
     helm.sh/hook-weight: "5"
     helm.sh/hook-delete-policy: before-hook-creation
-    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook: Sync
     argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+    argocd.argoproj.io/sync-wave: "5"
 spec:
   backoffLimit: 0
   activeDeadlineSeconds: {{ .Values.jinbe.bootstrap.activeDeadlineSeconds | default 600 }}

--- a/charts/auth/templates/jinbe/deployment.yaml
+++ b/charts/auth/templates/jinbe/deployment.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "auth.jinbe.fullname" . }}
   labels:
     {{- include "auth.jinbe.labels" . | nindent 4 }}
+  annotations:
+    # Sync after the bootstrap Job (sync-wave 5). jinbe gates startup on the
+    # bootstrap marker; running this Deployment first would deadlock the sync.
+    argocd.argoproj.io/sync-wave: "10"
 spec:
   replicas: {{ .Values.jinbe.replicaCount }}
   selector:


### PR DESCRIPTION
## Summary

Fixes deadlock on fresh install introduced in 0.5.0 (PostSync hook).

- Bootstrap Job: `argocd.argoproj.io/hook: PostSync` → `Sync` + `sync-wave: \"5\"`
- jinbe Deployment: + `argocd.argoproj.io/sync-wave: \"10\"`
- Chart 0.5.0 → 0.5.1

## Why

jinbe v0.3.0 gates pod startup on the bootstrap marker. With the previous PostSync hook, the Job ran AFTER the entire Sync phase succeeded, but Sync waited on jinbe becoming Ready, which waited on the marker, which waited on the Job — chicken-and-egg deadlock on a fresh install.

With sync-wave, the Job runs as part of Sync at wave 5 (after redis/kratos at wave 0), completes, writes the marker, then jinbe Deployment is created at wave 10 and starts Ready immediately.

`helm.sh/*` annotations untouched — pure Helm install path uses post-install hooks as before. CLI idempotency unchanged (marker drift detection).

## Test plan

- [x] `helm template` renders correct sync-wave annotations (Job=5, Deploy=10)
- [x] `helm lint` passes
- [ ] CI `ct lint` passes
- [ ] After merge + publish, ArgoCD sync on auth-w6d shows Job created+completed before jinbe Deployment becomes Ready
- [ ] No deadlock on next fresh install