### PR TITLE
feat(auth): OPAL resilience — 3-layer fix for silent OPA-bindings-empty (chart 0.5.2)

### DIFF
--- a/charts/auth/Chart.yaml
+++ b/charts/auth/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: auth
 description: Complete authentication stack with Kratos, Oathkeeper, OPAL, Jinbe, and Redis
 type: application
-version: 0.5.0
+version: 0.5.1
 appVersion: "1.0.0"
 keywords:
   - auth

--- a/charts/auth/Chart.yaml
+++ b/charts/auth/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: auth
 description: Complete authentication stack with Kratos, Oathkeeper, OPAL, Jinbe, and Redis
 type: application
-version: 0.5.1
+version: 0.5.2
 appVersion: "1.0.0"
 keywords:
   - auth

--- a/charts/auth/charts/opal/templates/deployment-client.yaml
+++ b/charts/auth/charts/opal/templates/deployment-client.yaml
@@ -7,6 +7,10 @@ metadata:
   name: {{ $nm }}
   labels:
     {{- include "opal.clientLabels" . | nindent 4 }}
+  annotations:
+    # Sync after opal-server (sync-wave 11). Client pulls policy + data from
+    # the server, so server must be running first.
+    argocd.argoproj.io/sync-wave: "12"
 spec:
   replicas: {{ .Values.client.replicas }}
   selector:
@@ -110,6 +114,26 @@ spec:
             failureThreshold: 5
             timeoutSeconds: 10
             periodSeconds: 30
+          {{- if and .Values.client.requireBindings .Values.client.requireBindings.enabled }}
+          # Stay NotReady until OPA has actually loaded RBAC bindings from
+          # the data publisher. Catches the silent "OPA empty" failure mode
+          # where opal-server fetched the data sources too early and ended
+          # up with an empty dataset; without this probe, requests would
+          # cross the Service and get 403'd at runtime.
+          startupProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -e
+                  body=$(wget -qO- "http://127.0.0.1:{{ .Values.client.opaPort }}/v1/data/{{ .Values.client.requireBindings.path | default "bindings/group_membership" }}")
+                  echo "$body" | grep -q '"result"' || exit 1
+                  echo "$body" | grep -q '@' || exit 1
+            failureThreshold: {{ .Values.client.requireBindings.failureThreshold | default 60 }}
+            periodSeconds: {{ .Values.client.requireBindings.periodSeconds | default 5 }}
+            timeoutSeconds: 5
+          {{- end }}
           {{- if .Values.client.resources }}
           resources:
             {{- toYaml .Values.client.resources | nindent 12 }}

--- a/charts/auth/charts/opal/templates/deployment-server.yaml
+++ b/charts/auth/charts/opal/templates/deployment-server.yaml
@@ -7,6 +7,11 @@ metadata:
   name: {{ $nm }}
   labels:
     {{- include "opal.serverLabels" . | nindent 4 }}
+  annotations:
+    # Sync after the data-source publisher (jinbe, sync-wave 10). Without
+    # this, opal-server can boot first, hit a 503 from jinbe, give up, and
+    # leave OPA's bindings empty until a manual rollout restart.
+    argocd.argoproj.io/sync-wave: "11"
 spec:
   replicas: {{ .Values.server.replicas }}
   selector:
@@ -47,8 +52,36 @@ spec:
           emptyDir: {}
       {{- end }}
 
-      {{- if .Values.e2e }}
+      {{- if or .Values.e2e (and .Values.server.waitForDataSource .Values.server.waitForDataSource.enabled) }}
       initContainers:
+        {{- if and .Values.server.waitForDataSource .Values.server.waitForDataSource.enabled }}
+        - name: wait-for-data-source
+          # Polls the external data source URL until it returns a healthy
+          # response, then exits. Prevents opal-server from booting, fetching
+          # an empty dataset, and silently leaving OPA without bindings.
+          # Configured via .Values.server.waitForDataSource.url.
+          image: {{ .Values.server.waitForDataSource.image | default "curlimages/curl:8.10.1" | quote }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              URL='{{ .Values.server.waitForDataSource.url }}'
+              echo "waiting for data source: $URL"
+              attempts=0
+              max={{ .Values.server.waitForDataSource.maxAttempts | default 120 }}
+              until curl --silent --fail --max-time 5 "$URL" > /dev/null; do
+                attempts=$((attempts+1))
+                if [ "$attempts" -ge "$max" ]; then
+                  echo "data source still unreachable after $max attempts — giving up"
+                  exit 1
+                fi
+                echo "  attempt $attempts/$max — sleeping 2s"
+                sleep 2
+              done
+              echo "data source ready"
+        {{- end }}
+        {{- if .Values.e2e }}
         - name: git-init
           image: {{ include "opal.serverImage" . | quote }}
           imagePullPolicy: IfNotPresent
@@ -84,6 +117,7 @@ spec:
               git push
 
               echo ">>>> HEAD: $(git rev-parse --short HEAD) <<<<"
+        {{- end }}
       {{- end }}
       containers:
         - name: opal-server

--- a/charts/auth/templates/jinbe/bootstrap-job.yaml
+++ b/charts/auth/templates/jinbe/bootstrap-job.yaml
@@ -16,6 +16,12 @@
 
   Dual annotations: helm.sh/* for `helm install/upgrade`, argocd.argoproj.io/*
   for ArgoCD's hook lifecycle. Both are honored in their respective tools.
+
+  ArgoCD ordering: `hook: Sync` runs as part of the main Sync phase (not
+  post-Sync) with `sync-wave: "5"`, so it executes BEFORE the jinbe
+  Deployment (sync-wave: "10"). Required because jinbe gates startup on the
+  bootstrap marker — if the Job ran post-Sync, jinbe would never become
+  Ready and Sync would deadlock.
 */}}
 apiVersion: batch/v1
 kind: Job
@@ -28,8 +34,9 @@ metadata:
     helm.sh/hook: post-install,post-upgrade
     helm.sh/hook-weight: "5"
     helm.sh/hook-delete-policy: before-hook-creation
-    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook: Sync
     argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+    argocd.argoproj.io/sync-wave: "5"
 spec:
   backoffLimit: 0
   activeDeadlineSeconds: {{ .Values.jinbe.bootstrap.activeDeadlineSeconds | default 600 }}

--- a/charts/auth/templates/jinbe/deployment.yaml
+++ b/charts/auth/templates/jinbe/deployment.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "auth.jinbe.fullname" . }}
   labels:
     {{- include "auth.jinbe.labels" . | nindent 4 }}
+  annotations:
+    # Sync after the bootstrap Job (sync-wave 5). jinbe gates startup on the
+    # bootstrap marker; running this Deployment first would deadlock the sync.
+    argocd.argoproj.io/sync-wave: "10"
 spec:
   replicas: {{ .Values.jinbe.replicaCount }}
   selector:

--- a/charts/auth/values.yaml
+++ b/charts/auth/values.yaml
@@ -304,6 +304,16 @@ opal:
       external_source_url: ""  # Auto: http://{release}-auth-jinbe:8080/api/admin/rbac/opal-datasource
       # Override in environment-specific values with actual Jinbe URL
 
+    # Init container that polls the data publisher (jinbe) until it serves
+    # /api/admin/rbac/opal-datasource. Defends against the failure mode where
+    # opal-server boots first, gets a 503, gives up, and leaves OPA with an
+    # empty bindings dataset until a manual rollout restart.
+    waitForDataSource:
+      enabled: true
+      url: ""  # Required when enabled — set per-release to the jinbe datasource URL
+      image: "curlimages/curl:8.10.1"
+      maxAttempts: 120  # 120 * 2s = 4 minutes total wait
+
   client:
     port: 7000
     opaPort: 8181
@@ -311,6 +321,15 @@ opal:
     # NOTE: Must be overridden per-release since OPAL subchart doesn't support tpl
     # Use: --set opal.client.serverUrl=http://{release}-opal-server:7002
     serverUrl: ""  # Auto-computed by OPAL subchart if empty
+
+    # Block opal-client Ready until OPA has loaded actual RBAC bindings from
+    # the publisher. Without this, the client can be Ready while OPA's
+    # dataset is empty, causing silent 403s for valid super-admin users.
+    requireBindings:
+      enabled: true
+      path: "bindings/group_membership"  # OPA path that must contain at least one '@'
+      failureThreshold: 60               # 60 * 5s = 5 min before pod is killed
+      periodSeconds: 5
 
 # =============================================================================
 # Jinbe - RBAC API & OPA Bundle Server


### PR DESCRIPTION
Three-layer defense preventing the silent OPA-bindings-empty failure mode that caused all admins to get 403 after any restart of opal-server (issue #150).

## Layers

1. **opal-server initContainer `wait-for-data-source`** — polls publisher URL (jinbe `/api/admin/rbac/opal-datasource`) until 200; pod stays pending until the data source is reachable.
2. **opal-client startupProbe `requireBindings`** — checks OPA's bindings/group_membership for at least one '@'; pod stays NotReady until OPA has loaded actual RBAC bindings.
3. **argocd sync-wave**: opal-server=11, opal-client=12 — strict ordering after jinbe Deployment (wave 10).

Layer 3 supplement is in jinbe v0.3.1 (PR w6d-io/jinbe#16): jinbe pushes a full datasource refresh to opal-server post-bootstrap, so even if opal-server boots first and ends up empty, the next jinbe boot repopulates without manual intervention.

## Configurable

```yaml
opal:
  server:
    waitForDataSource:
      enabled: true
      url: http://...-jinbe:8080/api/admin/rbac/opal-datasource
      image: curlimages/curl:8.10.1
      maxAttempts: 120  # 4 minutes
  client:
    requireBindings:
      enabled: true
      path: bindings/group_membership
      failureThreshold: 60
      periodSeconds: 5
```

## Stress test

Killed jinbe + opal-server + opal-clients simultaneously on dev cluster; all 3 layers held the system NotReady until data flowed end-to-end, then converged Ready without manual intervention. OPA bindings populated automatically (7 users restored).

Closes #150.