### PR TITLE
feat(gotenberg): new chart with Linkerd serverApiVersion + accessPolicy knobs

### DIFF
--- a/charts/gotenberg/.helmignore
+++ b/charts/gotenberg/.helmignore
@@ -1,0 +1,18 @@
+# Patterns to ignore when building packages.
+.DS_Store
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/gotenberg/Chart.yaml
+++ b/charts/gotenberg/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+name: gotenberg
+description: A Helm chart for Gotenberg — a Docker-powered stateless API for PDF files.
+type: application
+keywords:
+  - gotenberg
+  - pdf
+  - office
+  - converter
+home: https://gotenberg.dev/
+sources:
+  - https://github.com/gotenberg/gotenberg
+maintainers:
+  - name: WILDCARD
+    url: https://w6d.io
+icon: https://w6d.io/favicon.ico
+appVersion: "8"
+version: 0.1.0

--- a/charts/gotenberg/NOTES.txt
+++ b/charts/gotenberg/NOTES.txt
@@ -1,0 +1,17 @@
+Thank you for installing Gotenberg.
+
+Release: {{ .Release.Name }}
+Namespace: {{ .Release.Namespace }}
+Chart: {{ .Chart.Name }}-{{ .Chart.Version }} (app {{ .Chart.AppVersion }})
+
+To reach the service from within the cluster:
+  http://{{ include "gotenberg.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}
+
+Quick smoke test (run from an inside-cluster pod or kubectl port-forward):
+  curl -sf http://{{ include "gotenberg.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}/health
+
+{{- if .Values.linkerd.enabled }}
+
+Linkerd policy: {{ .Values.linkerd.serverApiVersion }} on port {{ .Values.linkerd.port }} ({{ .Values.linkerd.proxyProtocol }}).
+  - Override serverApiVersion to policy.linkerd.io/v1beta1 on clusters running Linkerd ≤ 2.14.
+{{- end }}

--- a/charts/gotenberg/README.md
+++ b/charts/gotenberg/README.md
@@ -1,0 +1,97 @@
+# Gotenberg
+
+Helm chart for [Gotenberg](https://gotenberg.dev/) — a stateless API for Office → PDF conversion.
+
+Modelled on the [`nager`](../nager) chart structure with extensions for Gotenberg's runtime needs:
+read-only root filesystem with tmpfs scratch volumes, strict pod security, Linkerd policy with
+`apiVersion` toggle for older meshes, and per-policy NetworkPolicy list.
+
+## Installation
+
+```bash
+helm install gotenberg ./charts/gotenberg -n gotenberg --create-namespace
+```
+
+## Linkerd version toggle
+
+The Server CRD uses different `apiVersion` across Linkerd releases. Set `linkerd.serverApiVersion`
+to match your cluster:
+
+| Linkerd release | `linkerd.serverApiVersion` |
+| --- | --- |
+| ≥ 2.15 / edge-25.x | `policy.linkerd.io/v1beta3` *(default)* |
+| ≤ 2.14 | `policy.linkerd.io/v1beta1` |
+
+Mismatch on this single field was the root cause of incident SIS-2152 — qualif on Linkerd 2.14
+rejected a `v1beta3` manifest. The chart prevents the regression as long as the env-specific
+values file is correct.
+
+## Values overview
+
+| Key | Default | Notes |
+| --- | --- | --- |
+| `replicaCount` | `1` | |
+| `image.repository` | `gotenberg/gotenberg` | |
+| `image.tag` | `""` (= `Chart.AppVersion`, `8`) | |
+| `args` | `[gotenberg, --api-port=3000, --api-timeout=60s]` | First element must be `gotenberg`. |
+| `containerPort` | `3000` | |
+| `service.port` | `3000` | Matches `containerPort` by default. |
+| `podSecurityContext` | `runAsNonRoot:true, runAsUser/Group/fsGroup:1001, seccomp:RuntimeDefault` | |
+| `securityContext` | `allowPrivilegeEscalation:false, readOnlyRootFilesystem:true, capabilities.drop:[ALL]` | |
+| `volumes.tmp` | `emptyDir { medium: Memory, sizeLimit: 256Mi }` | Mounted at `/tmp/gotenberg`. |
+| `volumes.home` | `emptyDir { sizeLimit: 64Mi }` | Mounted at `/home/gotenberg`. |
+| `automountServiceAccountToken` | `false` | Pod and SA. |
+| `namespace.create` | `false` | Leave false when Argo creates the namespace. |
+| `linkerd.enabled` | `true` | Render Server + AuthorizationPolicy. |
+| `linkerd.serverApiVersion` | `policy.linkerd.io/v1beta3` | Override to `v1beta1` on older meshes. |
+| `networkPolicies` | 3 entries — default-deny, allow-time-tenants-ingress, allow-egress-dns | Each entry is rendered verbatim. `podSelector` defaults to the chart selectorLabels if omitted. |
+
+## NetworkPolicies
+
+Chart defaults are zero-trust generic and apply everywhere Gotenberg runs:
+
+- `default-deny` — closes both Ingress and Egress on every pod in the namespace.
+- `allow-egress-dns` — allows DNS (UDP/TCP 53) to `kube-system/kube-dns`.
+
+**Ingress allow rules are not in the chart** — they depend on which client
+namespaces and pod labels are allowed to reach Gotenberg, which is deployment-
+specific (different namespace selectors / pod labels across envs). Add them
+in your consumer values file, e.g.:
+
+```yaml
+networkPolicies:
+  - name: default-deny
+    podSelector: {}
+    policyTypes: [Ingress, Egress]
+  - name: allow-clients-ingress
+    policyTypes: [Ingress]
+    ingress:
+      - from:
+          - namespaceSelector:
+              matchLabels:
+                <your-namespace-label>: <value>
+            podSelector:
+              matchLabels:
+                <your-client-pod-label>: <value>
+        ports:
+          - port: 3000
+            protocol: TCP
+  - name: allow-egress-dns
+    policyTypes: [Egress]
+    egress:
+      # ...same as chart default
+```
+
+Note: `networkPolicies` is a list, and Helm/yq value-merges replace lists
+entirely (no concatenation). Redefine the full list in your env values when
+adding rules.
+
+### Linkerd identity vs NetworkPolicy
+
+The Linkerd `AuthorizationPolicy` rendered by this chart is `allow-all`
+(`requiredAuthenticationRefs: []`). If the consumer namespaces fan out
+(e.g. one per tenant), enumerating each one as a `MeshTLSAuthentication`
+identity is not practical and L7 identity restriction stays off — L3/L4
+NetworkPolicy gates access. If you have a small fixed set of clients, swap
+the `allow-all` for an explicit list (see `charts/app/templates/linkerd/policy.yaml`
+for a pattern that fits in this chart).

--- a/charts/gotenberg/templates/_helpers.tpl
+++ b/charts/gotenberg/templates/_helpers.tpl
@@ -1,0 +1,69 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "gotenberg.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "gotenberg.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Chart name and version label.
+*/}}
+{{- define "gotenberg.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "gotenberg.labels" -}}
+helm.sh/chart: {{ include "gotenberg.chart" . }}
+{{ include "gotenberg.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels — stable subset used in matchLabels.
+*/}}
+{{- define "gotenberg.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "gotenberg.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Name of the ServiceAccount to use.
+*/}}
+{{- define "gotenberg.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "gotenberg.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Image reference (repository:tag) — falls back to .Chart.AppVersion if values.image.tag is empty.
+*/}}
+{{- define "gotenberg.image" -}}
+{{- $tag := .Values.image.tag | default .Chart.AppVersion }}
+{{- printf "%s:%s" .Values.image.repository $tag }}
+{{- end }}

--- a/charts/gotenberg/templates/deployment.yaml
+++ b/charts/gotenberg/templates/deployment.yaml
@@ -1,0 +1,92 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "gotenberg.fullname" . }}
+  labels:
+    {{- include "gotenberg.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  strategy:
+    {{- toYaml .Values.strategy | nindent 4 }}
+  selector:
+    matchLabels:
+      {{- include "gotenberg.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "gotenberg.labels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "gotenberg.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ include "gotenberg.name" . }}
+          image: {{ include "gotenberg.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            {{- toYaml .Values.args | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.containerPort }}
+              protocol: TCP
+          {{- with .Values.env }}
+          env:
+            {{- range $k, $v := . }}
+            - name: {{ $k }}
+              value: {{ $v | quote }}
+            {{- end }}
+          {{- end }}
+          {{- with .Values.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp/gotenberg
+            - name: home
+              mountPath: /home/gotenberg
+      volumes:
+        - name: tmp
+          emptyDir:
+            {{- with .Values.volumes.tmp.medium }}
+            medium: {{ . }}
+            {{- end }}
+            {{- with .Values.volumes.tmp.sizeLimit }}
+            sizeLimit: {{ . }}
+            {{- end }}
+        - name: home
+          emptyDir:
+            {{- with .Values.volumes.home.sizeLimit }}
+            sizeLimit: {{ . }}
+            {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/gotenberg/templates/linkerd-policy.yaml
+++ b/charts/gotenberg/templates/linkerd-policy.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.linkerd.enabled }}
+{{- $fullname := include "gotenberg.fullname" . -}}
+apiVersion: {{ .Values.linkerd.serverApiVersion }}
+kind: Server
+metadata:
+  name: {{ $fullname }}-server
+  labels:
+    {{- include "gotenberg.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "gotenberg.selectorLabels" . | nindent 6 }}
+  port: {{ .Values.linkerd.port }}
+  proxyProtocol: {{ .Values.linkerd.proxyProtocol }}
+  {{- if and .Values.linkerd.accessPolicy (eq .Values.linkerd.serverApiVersion "policy.linkerd.io/v1beta3") }}
+  accessPolicy: {{ .Values.linkerd.accessPolicy }}
+  {{- end }}
+---
+apiVersion: policy.linkerd.io/v1alpha1
+kind: AuthorizationPolicy
+metadata:
+  name: {{ $fullname }}-allow-all
+  labels:
+    {{- include "gotenberg.labels" . | nindent 4 }}
+spec:
+  targetRef:
+    group: policy.linkerd.io
+    kind: Server
+    name: {{ $fullname }}-server
+  requiredAuthenticationRefs: []
+{{- end }}

--- a/charts/gotenberg/templates/namespace.yaml
+++ b/charts/gotenberg/templates/namespace.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.namespace.create -}}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Release.Namespace }}
+  labels:
+    name: {{ .Release.Namespace }}
+    {{- with .Values.namespace.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/charts/gotenberg/templates/networkpolicy.yaml
+++ b/charts/gotenberg/templates/networkpolicy.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.networkPolicies }}
+{{- $labels := (include "gotenberg.labels" .) }}
+{{- $selectorLabels := (include "gotenberg.selectorLabels" .) }}
+{{- $fullname := (include "gotenberg.fullname" .) }}
+{{- range .Values.networkPolicies }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .name }}
+  labels:
+    {{- $labels | nindent 4 }}
+spec:
+  {{- if hasKey . "podSelector" }}
+  podSelector:
+    {{- toYaml .podSelector | nindent 4 }}
+  {{- else }}
+  podSelector:
+    matchLabels:
+      {{- $selectorLabels | nindent 6 }}
+  {{- end }}
+  policyTypes:
+    {{- toYaml .policyTypes | nindent 4 }}
+  {{- with .ingress }}
+  ingress:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .egress }}
+  egress:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/gotenberg/templates/service.yaml
+++ b/charts/gotenberg/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "gotenberg.fullname" . }}
+  labels:
+    {{- include "gotenberg.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    {{- include "gotenberg.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP

--- a/charts/gotenberg/templates/serviceaccount.yaml
+++ b/charts/gotenberg/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "gotenberg.serviceAccountName" . }}
+  labels:
+    {{- include "gotenberg.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/charts/gotenberg/values.yaml
+++ b/charts/gotenberg/values.yaml
@@ -1,0 +1,135 @@
+replicaCount: 1
+
+image:
+  repository: gotenberg/gotenberg
+  pullPolicy: IfNotPresent
+  tag: ""
+
+nameOverride: ""
+fullnameOverride: ""
+
+strategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxUnavailable: 0
+    maxSurge: 1
+
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+  automountServiceAccountToken: false
+
+automountServiceAccountToken: false
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1001
+  runAsGroup: 1001
+  fsGroup: 1001
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop: ["ALL"]
+
+# Gotenberg CLI args. The first element MUST be "gotenberg" (entrypoint).
+args:
+  - gotenberg
+  - --api-port=3000
+  - --api-timeout=60s
+
+# Container port name reused by Service.targetPort, probes and Linkerd Server.
+containerPort: 3000
+
+env:
+  TMPDIR: /tmp/gotenberg
+
+resources:
+  requests:
+    cpu: 200m
+    memory: 512Mi
+  limits:
+    cpu: 1000m
+    memory: 1Gi
+
+livenessProbe:
+  httpGet:
+    path: /health
+    port: http
+  initialDelaySeconds: 10
+  periodSeconds: 30
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /health
+    port: http
+  initialDelaySeconds: 3
+  periodSeconds: 10
+  timeoutSeconds: 3
+  failureThreshold: 3
+
+# Gotenberg writes scratch PDFs to /tmp/gotenberg with readOnlyRootFilesystem — mount tmpfs.
+# /home/gotenberg is touched by some converters too.
+volumes:
+  tmp:
+    sizeLimit: 256Mi
+    medium: Memory
+  home:
+    sizeLimit: 64Mi
+
+service:
+  type: ClusterIP
+  port: 3000
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+# Namespace creation. Leave false when Argo creates the namespace via syncOptions.
+namespace:
+  create: false
+  labels:
+    linkerd.io/inject: enabled
+
+# Linkerd policy. Set serverApiVersion to v1beta1 on Linkerd ≤ 2.14 (qualif on Strada).
+# v1beta3 on edge-25.x / Linkerd ≥ 2.15.
+# accessPolicy=audit matches the Strada fleet convention (observe-only, no enforcement) —
+# AuthorizationPolicy allow-all handles the actual traffic; audit gives L7 visibility.
+# Only meaningful when serverApiVersion is v1beta3+ (the field doesn't exist on v1beta1).
+linkerd:
+  enabled: true
+  serverApiVersion: policy.linkerd.io/v1beta3
+  accessPolicy: audit
+  port: http
+  proxyProtocol: HTTP/1
+
+# NetworkPolicies. Each entry is rendered as a separate object.
+# Defaults are GENERIC (chart-as-library): zero-trust default-deny + DNS egress.
+# Ingress allow rules (which clients can reach Gotenberg) are deployment-specific
+# and MUST be defined per-environment in the consumer values file — see README.
+# To override, redefine the full list (yq merge replaces lists, not concatenates).
+networkPolicies:
+  - name: default-deny
+    podSelector: {}
+    policyTypes: [Ingress, Egress]
+  - name: allow-egress-dns
+    policyTypes: [Egress]
+    egress:
+      - to:
+          - namespaceSelector:
+              matchLabels:
+                kubernetes.io/metadata.name: kube-system
+            podSelector:
+              matchLabels:
+                k8s-app: kube-dns
+        ports:
+          - port: 53
+            protocol: UDP
+          - port: 53
+            protocol: TCP


### PR DESCRIPTION
Adds `charts/gotenberg/`, the Helm chart for Gotenberg (Office → PDF stateless API). Structure modelled on `charts/nager`; runtime specifics (CLI args, securityContext, emptyDir tmpfs, NetworkPolicies, Linkerd Server) are values-driven.

## Why

- The current Gotenberg deployment lives as raw manifests under `infra/k8s/{dev-aws-1,qua-gcp-1,prod-gcp-2}/gotenberg/` with a separate `gitops/gotenberg` repo for Argo Applications. Target layout is the `strada/tools/<svc>` pattern (Dockerfile + CI + `.values/`), which expects a packaged Helm chart in the OCI registry.
- Incident **SIS-2152** (2026-05-06) was caused by a Linkerd `Server` manifest pinned to `policy.linkerd.io/v1beta3` hitting qualif on Linkerd 2.14 (v1beta1 max). This chart exposes `linkerd.serverApiVersion` as a values knob so each env stays aligned with its mesh version.

## What the chart covers

- `ServiceAccount` + `Deployment` + `Service` (port 3000, named `http`)
- Pod-level `automountServiceAccountToken: false` (also on the SA)
- Strict pod `securityContext`: runAsNonRoot/User/Group/fsGroup=1001, `seccompProfile=RuntimeDefault`
- Strict container `securityContext`: `allowPrivilegeEscalation=false`, `readOnlyRootFilesystem=true`, `capabilities.drop=[ALL]`
- tmpfs `emptyDir` at `/tmp/gotenberg` (Memory, 256Mi default) + `emptyDir` at `/home/gotenberg` (64Mi) — required by read-only rootfs
- Liveness/readiness on `/health`
- Generic `NetworkPolicies` loop on `values.networkPolicies` — defaults are zero-trust only (`default-deny` + `allow-egress-dns`). **Ingress allow rules are deployment-specific** (different ns/pod labels across envs) and live in the consumer values file — see README.
- Linkerd `Server` + `AuthorizationPolicy` templated:
  - `serverApiVersion` knob (`v1beta3` default for Linkerd ≥ 2.15, `v1beta1` for ≤ 2.14)
  - `accessPolicy=audit` default on `v1beta3` (matches fleet convention: observe-only, AuthZ allow-all does the actual allow)
  - `accessPolicy` skipped automatically when `serverApiVersion=v1beta1` (field absent in that CRD version)
- Optional `Namespace` (off by default — Argo handles ns creation)

## Verification

`helm lint` + `helm template` against three env scenarios:

| Env | `serverApiVersion` | `accessPolicy` rendered | NetworkPolicies |
| --- | --- | --- | --- |
| dev | v1beta3 | audit | restrictive (default-deny + allow-clients + dns) |
| qualif | v1beta1 | skipped | restrictive |
| prod | v1beta3 (default) | audit | restrictive |

Rendered manifests structurally match the existing `infra/k8s/<cluster>/gotenberg/*.yaml` modulo standard Helm labels.