### PR TITLE
chore(auth): bump jinbe v0.5.1 + kuma v2.6.1 (chart 0.7.2)

### DIFF
--- a/charts/auth/Chart.yaml
+++ b/charts/auth/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: auth
 description: Complete authentication stack with Kratos, Oathkeeper, OPAL, Jinbe, and Redis
 type: application
-version: 0.7.0
-appVersion: "0.5.0"
+version: 0.7.2
+appVersion: "0.5.1"
 keywords:
   - auth
   - kratos

--- a/charts/auth/values.yaml
+++ b/charts/auth/values.yaml
@@ -465,10 +465,14 @@ jinbe:
   #   --set jinbe.image.tag=latest
   image:
     repository: ghcr.io/w6d-io/jinbe
-    # Image tags carry the `v` prefix (v0.5.0), Chart.appVersion does not
-    # (0.5.0). Hard-pin here so the chart's default install resolves to
-    # an existing tag without relying on the fallback.
-    tag: "v0.5.0"
+    # Image tags carry the `v` prefix (v0.5.x), Chart.appVersion does not.
+    # Hard-pin here so the chart's default install resolves to an existing
+    # tag without relying on the fallback. v0.5.1 ships the
+    # notifyOpal/notifyOpalRoles fix so every RBAC mutation publishes the
+    # full data-source list (incl. /route_map/{service}); previously a
+    # route added through the admin UI never reached OPA until an
+    # opal-client restart.
+    tag: "v0.5.1"
     pullPolicy: IfNotPresent
 
   service:
@@ -756,7 +760,15 @@ adminUi:
   replicaCount: 1
   image:
     repository: ghcr.io/w6d-io/kuma
-    tag: "v2.6.0"
+    # v2.6.1 fixes the false-positive MFA badge: real enrolment is now
+    # derived from credentials.totp.config.totp_url /
+    # credentials.webauthn.config.credentials[] /
+    # credentials.lookup_secret.config.recovery_codes[] rather than
+    # credential-key presence. Earlier images flagged every freshly
+    # registered user as MFA-enabled because Kratos auto-creates an
+    # empty credentials.webauthn entry when the schema declares webauthn
+    # as an identifier.
+    tag: "v2.6.1"
     pullPolicy: IfNotPresent
   env:
     NEXT_PUBLIC_API_URL: ""  # Auto: https://app.{domain}


### PR DESCRIPTION
## Summary

Two image bumps shipped together as chart \`0.7.2\`.

### jinbe v0.5.1

Fixes the OPAL publish-on-mutation regression in v0.5.0. \`notifyOpal\` and \`notifyOpalRoles\` previously published only a slim subset of data-source entries (\`/bindings\`, \`/bindings/groups\`, and per-service \`/roles\`) but not \`/route_map/{service}\`. Result: a route added or edited in the admin UI never reached OPA — the data sat in Redis but OPA's in-memory \`data.route_map\` stayed stale until an opal-client restart re-pulled every source at boot.

v0.5.1 delegates both notify paths to \`refreshAllDataSources\`, publishing every entry the chart's \`opal-datasource\` endpoint returns. Slight over-publish (OPAL clients re-fetch URLs they already know) in exchange for a guarantee that any RBAC mutation propagates without manual intervention. See \`w6d-io/jinbe#30\`.

### kuma v2.6.1

Fixes the false-positive \`🔐 enabled\` MFA badge on the Users page. The previous \`mfa\` derivation checked credential **key presence**:

\`\`\`ts
if (c.totp || c.webauthn || c.lookup_secret) mfa = true
\`\`\`

Kratos auto-creates a \`credentials.webauthn\` entry with just a \`user_handle\` for every identity whose schema declares webauthn as an identifier — even when no security key has actually been registered. The check therefore returned \`true\` for every freshly registered user, defeating the privilege-escalation MFA gate's purpose on the UI side.

v2.6.1 looks at the real enrolment artefact inside each credential's \`config\`:

| Method | Signal |
|---|---|
| totp | \`config.totp_url\` |
| webauthn | \`config.credentials[]\` non-empty |
| lookup_secret | \`config.recovery_codes[]\` non-empty |

See \`w6d-io/kuma#8\`. The matching backend fix landed in \`w6d-io/jinbe#31\` (\`hasMFA()\`).

## Compatibility

Backwards compatible — no chart-side schema changes. Operators pinning either image to an older tag continue to work; the chart only fills the default.

## Test plan

- [x] \`helm lint\` clean.
- [x] \`helm template\` renders both new tags.
- [x] Smoke-tested in a non-prod test namespace: route added through the admin UI is visible at \`http://opal-client:8181/v1/data/route_map/<service>\` within the OPAL polling window without restarting opal-client; freshly registered users render as \`⚠️ off\` on the Users page until they actually enrol a factor.