### PR TITLE
feat(auth): release-prefix error-page Service + parent-owned oathkeeper proxy Ingress (chart 0.7.3)

### DIFF
--- a/charts/auth/Chart.yaml
+++ b/charts/auth/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: auth
 description: Complete authentication stack with Kratos, Oathkeeper, OPAL, Jinbe, and Redis
 type: application
-version: 0.7.2
+version: 0.7.3
 appVersion: "0.5.1"
 keywords:
   - auth

--- a/charts/auth/examples/example-org-values.yaml
+++ b/charts/auth/examples/example-org-values.yaml
@@ -124,11 +124,50 @@ jinbe:
     # then the marker key rbac:bootstrap:state in Redis prevents re-runs.
     # Rotate the password via Kratos settings flow after first login;
     # in production replace these literals with Vault references.
+    #
+    # ADMIN_PASSWORD must be at least 16 chars and must NOT start with
+    # a well-known weak prefix (`changeme`, `password`, `admin`, `123`,
+    # case-insensitive). Both the zod schema and a runtime guard in the
+    # bootstrap CLI enforce this — example value below is a placeholder
+    # only; rotate in your own overlay or wire it from Vault.
     ADMIN_EMAIL: admin@example.org
-    ADMIN_PASSWORD: changeme-example-org-2026
+    ADMIN_PASSWORD: ExampleOrgInitialBootstrap2026!
     ADMIN_NAME: Example Org Admin
     ENCRYPTION_KEY: changeme-32char-example-org-poc-aa
     CORS_ORIGIN: https://kuma.example.org,https://auth.example.org,https://jinbe.example.org,https://dummy.example.org
+
+# -----------------------------------------------------------------------------
+# Multi-organization illustration (Path 3 hybrid)
+# -----------------------------------------------------------------------------
+# The chart's Kratos identity schema declares `metadata_admin.organizations`
+# as an array of UUIDs (see values.yaml). That field is admin-only and is
+# populated through the jinbe API (PUT /api/admin/users/:email/organizations)
+# after install, not through Helm values — Kratos itself does not validate
+# metadata against the schema. The OPA rego policy uses the array (mirrored
+# into Redis as `bindings.user_organizations[email]`) to decide whether a
+# request whose `X-Tenant-Id` is set may proceed.
+#
+# Example identity (illustration only, shown in the Kratos JSON shape):
+#
+#   {
+#     "traits": {
+#       "email": "alice@example.org",
+#       "name": "Alice",
+#       "picture": "https://cdn.example.org/u/alice.png"
+#     },
+#     "metadata_admin": {
+#       "organizations": [
+#         "11111111-1111-1111-1111-111111111111",
+#         "22222222-2222-2222-2222-222222222222"
+#       ]
+#     }
+#   }
+#
+# Browsers attach `X-Tenant-Id: <uuid>` on each org-scoped request; oathkeeper
+# forwards it through opa-authz-proxy, and rego rejects if the UUID is not in
+# the identity's `organizations` array. The legacy single-org pointer
+# `traits.organization_id` (when a tenant schema declares it) remains
+# acceptable as a fallback for the same-org case — that's the "hybrid" bit.
 
 # Inline 401/403/404 pages — same host, no cross-domain redirect.
 # Override the palette/copy to match the tenant's brand; all values

--- a/charts/auth/examples/example-org-values.yaml
+++ b/charts/auth/examples/example-org-values.yaml
@@ -61,38 +61,40 @@ kratos:
             after:
               default_browser_return_url: https://auth.example.org/login
 
-oathkeeper:
-  ingress:
-    proxy:
-      enabled: true
-      # Pick the IngressClass watched by the controller that fronts your
-      # cluster (kubectl get ingressclass). "nginx" is the upstream
-      # ingress-nginx default.
-      className: nginx
-      # Override CORS allow-origin: the chart default of "*" is rejected
-      # by browsers when the request carries credentials (cookies). List
-      # the tenant origins explicitly; ingress-nginx echoes back the one
-      # that matches the request's Origin header so credentialed
-      # XHR/fetch from kuma → jinbe succeeds.
-      annotations:
-        nginx.ingress.kubernetes.io/cors-allow-origin: "https://kuma.example.org,https://auth.example.org,https://jinbe.example.org,https://dummy.example.org"
-      hosts:
-        - host: auth.example.org
-          paths:
-            - path: /
-              pathType: ImplementationSpecific
-        - host: kuma.example.org
-          paths:
-            - path: /
-              pathType: ImplementationSpecific
-        - host: jinbe.example.org
-          paths:
-            - path: /
-              pathType: ImplementationSpecific
-        - host: dummy.example.org
-          paths:
-            - path: /
-              pathType: ImplementationSpecific
+# The oathkeeper proxy Ingress lives at the parent-chart top level
+# (`oathkeeperProxyIngress:`) since chart 0.7.3 so that annotation values
+# can reference `{{ .Release.Name }}` through a real `tpl` pass. The
+# schema mirrors the previous `oathkeeper.ingress.proxy.*` keys 1:1.
+oathkeeperProxyIngress:
+  enabled: true
+  # Pick the IngressClass watched by the controller that fronts your
+  # cluster (kubectl get ingressclass). "nginx" is the upstream
+  # ingress-nginx default.
+  className: nginx
+  # Override CORS allow-origin: the chart default of "*" is rejected
+  # by browsers when the request carries credentials (cookies). List
+  # the tenant origins explicitly; ingress-nginx echoes back the one
+  # that matches the request's Origin header so credentialed
+  # XHR/fetch from kuma → jinbe succeeds.
+  annotations:
+    nginx.ingress.kubernetes.io/cors-allow-origin: "https://kuma.example.org,https://auth.example.org,https://jinbe.example.org,https://dummy.example.org"
+  hosts:
+    - host: auth.example.org
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+    - host: kuma.example.org
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+    - host: jinbe.example.org
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+    - host: dummy.example.org
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
 
 kratosLoginUi:
   kratos:

--- a/charts/auth/templates/_helpers.tpl
+++ b/charts/auth/templates/_helpers.tpl
@@ -271,6 +271,30 @@ Auth domain
 {{- end }}
 
 {{/*
+Oathkeeper fullname — mirrors the upstream `oathkeeper.fullname` helper so
+that parent-side templates (e.g. templates/oathkeeper/ingress-proxy.yaml)
+can reference subchart-owned resources (Services, ConfigMaps) by name
+without invoking the subchart's named template (which is out of scope from
+the parent's perspective).
+
+If a deployer sets `oathkeeper.fullnameOverride`, this helper honours it.
+Otherwise it reproduces the subchart's "release name contains chart name"
+short-circuit, falling back to `<release>-<chart>`.
+*/}}
+{{- define "auth.oathkeeper.fullname" -}}
+{{- if .Values.oathkeeper.fullnameOverride -}}
+{{- .Values.oathkeeper.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default "oathkeeper" .Values.oathkeeper.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 App domain
 */}}
 {{- define "auth.appDomain" -}}

--- a/charts/auth/templates/error-page/configmap.yaml
+++ b/charts/auth/templates/error-page/configmap.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.errorPage.enabled }}
-{{- $name := "error-page" }}
+{{- $name := printf "%s-error-page" .Release.Name }}
 {{- $brand := .Values.errorPage.branding }}
 {{- $appName := default .Values.global.domain $brand.appName }}
 {{- $homeUrl := default (printf "https://%s" (include "auth.appDomain" .)) $brand.homeUrl }}

--- a/charts/auth/templates/error-page/deployment.yaml
+++ b/charts/auth/templates/error-page/deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.errorPage.enabled }}
-{{- $name := "error-page" }}
+{{- $name := printf "%s-error-page" .Release.Name }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/auth/templates/error-page/service.yaml
+++ b/charts/auth/templates/error-page/service.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.errorPage.enabled }}
-{{- $name := "error-page" }}
+{{- $name := printf "%s-error-page" .Release.Name }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/auth/templates/oathkeeper/ingress-proxy.yaml
+++ b/charts/auth/templates/oathkeeper/ingress-proxy.yaml
@@ -1,0 +1,84 @@
+{{/*
+Vendored from the upstream Ory oathkeeper Helm chart 0.61.0
+(templates/ingress-proxy.yaml) into the parent chart so that
+ingress annotation values are evaluated through `tpl`. The
+upstream template renders `.Values.ingress.proxy.annotations`
+with bare `toYaml`, which means an annotation value like
+`{{ .Release.Name }}-error-page` is emitted literally and
+ingress-nginx's `default-backend` reroute cannot follow it.
+
+When bumping the oathkeeper subchart, diff this file against
+the new upstream `templates/ingress-proxy.yaml` and re-apply.
+The subchart's Ingress is forced off in `values.yaml`
+(`oathkeeper.ingress.proxy.enabled: false`) so this template is
+the sole emitter of the proxy Ingress.
+
+Inputs come from the parent-only `oathkeeperProxyIngress:` block.
+The schema mirrors the upstream subchart's `ingress.proxy.*` keys
+(annotations, className, hosts, tls, defaultBackend) — only the
+top-level location changes. Overlays that previously set
+`oathkeeper.ingress.proxy.*` must move those keys under
+`oathkeeperProxyIngress:`.
+*/}}
+{{- if .Values.oathkeeperProxyIngress.enabled -}}
+{{- $fullName := printf "%s-proxy" (include "auth.oathkeeper.fullname" .) -}}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  {{- if .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
+  labels:
+    app.kubernetes.io/name: oathkeeper
+    helm.sh/chart: {{ include "auth.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: oathkeeper-proxy
+  {{- with .Values.oathkeeperProxyIngress.annotations }}
+  annotations:
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+spec:
+  ingressClassName: {{ .Values.oathkeeperProxyIngress.className }}
+  {{- with .Values.oathkeeperProxyIngress.defaultBackend }}
+  defaultBackend:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- if .Values.oathkeeperProxyIngress.tls }}
+  tls:
+    {{- range .Values.oathkeeperProxyIngress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.oathkeeperProxyIngress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if .pathType }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: http
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: http
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/auth/values.yaml
+++ b/charts/auth/values.yaml
@@ -341,58 +341,78 @@ oathkeeper:
             config:
               verbose: false
 
+  # The subchart's Ingress emission is DISABLED here on purpose.
+  # The parent chart owns the proxy Ingress now (see the top-level
+  # `oathkeeperProxyIngress:` block below) so that annotation values can
+  # be `tpl`-evaluated and reference `{{ .Release.Name }}` — necessary
+  # for the release-prefixed error-page Service that ingress-nginx's
+  # `default-backend` reroute points at.
+  #
+  # Do NOT flip this back to `true` in an overlay; it would emit a
+  # second Ingress with the same name as the parent-owned one and the
+  # install/upgrade will fail with an ownership conflict.
   ingress:
     proxy:
-      enabled: true
-      className: ""
-      # ingress-nginx is the canonical CORS source. Annotations below
-      # cover ALL responses (including 401/403/500) since oathkeeper's
-      # rs/cors-based middleware does not touch error paths.
-      # The custom-http-errors=999 sentinel disables the cluster-wide
-      # custom-http-errors list for THIS Ingress only — without it,
-      # ingress-nginx ConfigMaps that route 4xx/5xx to a default error
-      # backend strip the JSON body and CORS headers, leaving SPA
-      # clients with "Failed to fetch" and no error.code visible.
-      # Override `cors-allow-origin` with the actual origins; defaults
-      # are derived from `global.{authDomain,appDomain}` via the
-      # auth.corsAllowOrigin helper.
-      annotations:
-        nginx.ingress.kubernetes.io/enable-cors: "true"
-        nginx.ingress.kubernetes.io/cors-allow-origin: "*"
-        nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
-        nginx.ingress.kubernetes.io/cors-allow-methods: "GET, POST, PUT, PATCH, DELETE, OPTIONS"
-        nginx.ingress.kubernetes.io/cors-allow-headers: "Content-Type, Authorization, X-Request-ID, Cookie, X-Requested-With"
-        nginx.ingress.kubernetes.io/cors-max-age: "600"
-        # Route 401/403/404 to the in-chart error-page Service so the
-        # browser sees a styled HTML page on the SAME host (e.g.
-        # kuma.{domain}/403) instead of being redirected to
-        # auth.{domain}/login for every authz error. 401 only fires
-        # for requests that don't match the redirect handler's
-        # text/html condition (XHR, fetch); HTML navigations still
-        # get the cross-host /login redirect from Oathkeeper above.
-        nginx.ingress.kubernetes.io/custom-http-errors: "401,403,404"
-        # Points at the literal Service name from
-        # templates/error-page/service.yaml. The oathkeeper subchart
-        # ingress template renders annotations with toYaml (no tpl pass),
-        # so this value cannot use {{ .Release.Name }} — the error-page
-        # Service is intentionally named without a release prefix so the
-        # annotation works under any release name.
-        nginx.ingress.kubernetes.io/default-backend: error-page
-      hosts:
-        - host: auth.example.com
-          paths:
-            - path: /
-              pathType: ImplementationSpecific
-        - host: app.example.com
-          paths:
-            - path: /
-              pathType: ImplementationSpecific
-      tls: []
+      enabled: false
+    api:
+      enabled: false
 
   # Access rules - now served by Jinbe HTTP endpoint
   # If you still need a static ConfigMap fallback, provide inline JSON here
   # externalAccessRulesConfigMap: "my-access-rules-configmap"
   accessRules: ""
+
+# =============================================================================
+# Oathkeeper Proxy Ingress — parent-chart-owned, replaces the subchart's
+# Ingress so annotation values get a real `tpl` pass (the subchart renders
+# annotations through bare `toYaml`, which strands `{{ .Release.Name }}`
+# inside the YAML literal). Inputs match the subchart's schema 1:1 so
+# overlays only need to rename the top-level key when migrating.
+# =============================================================================
+oathkeeperProxyIngress:
+  enabled: true
+  className: ""
+  # ingress-nginx is the canonical CORS source. Annotations below
+  # cover ALL responses (including 401/403/500) since oathkeeper's
+  # rs/cors-based middleware does not touch error paths.
+  # Annotations are passed through `tpl` by the parent template, so
+  # values may use Helm directives like `{{ .Release.Name }}`.
+  # Override `cors-allow-origin` with the actual origins; defaults
+  # are derived from `global.{authDomain,appDomain}`.
+  annotations:
+    nginx.ingress.kubernetes.io/enable-cors: "true"
+    nginx.ingress.kubernetes.io/cors-allow-origin: "*"
+    nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
+    nginx.ingress.kubernetes.io/cors-allow-methods: "GET, POST, PUT, PATCH, DELETE, OPTIONS"
+    nginx.ingress.kubernetes.io/cors-allow-headers: "Content-Type, Authorization, X-Request-ID, Cookie, X-Requested-With"
+    nginx.ingress.kubernetes.io/cors-max-age: "600"
+    # Route 401/403/404 to the in-chart error-page Service so the
+    # browser sees a styled HTML page on the SAME host (e.g.
+    # kuma.{domain}/403) instead of being redirected to
+    # auth.{domain}/login for every authz error. 401 only fires
+    # for requests that don't match the redirect handler's
+    # text/html condition (XHR, fetch); HTML navigations still
+    # get the cross-host /login redirect from Oathkeeper above.
+    nginx.ingress.kubernetes.io/custom-http-errors: "401,403,404"
+    # Points at the release-prefixed error-page Service from
+    # templates/error-page/service.yaml. `{{ .Release.Name }}` is
+    # resolved by the parent chart's `tpl` pass on annotations.
+    nginx.ingress.kubernetes.io/default-backend: '{{ .Release.Name }}-error-page'
+  hosts:
+    - host: auth.example.com
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+    - host: app.example.com
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  # Subchart-compatible spec.defaultBackend for unmatched paths within
+  # this Ingress. Distinct from the `default-backend` ANNOTATION above
+  # (which controls ingress-nginx's custom-http-errors reroute). Leave
+  # empty to drop the spec field entirely.
+  defaultBackend: {}
 
 # =============================================================================
 # OPAL - Policy Administration (Permit.io)

--- a/charts/auth/values.yaml
+++ b/charts/auth/values.yaml
@@ -187,6 +187,19 @@ kratos:
     # for those flows to attach correctly. Without `totp.account_name`
     # the QR/secret would have no human-readable label; without
     # `webauthn.identifier` registering a security key fails.
+    #
+    # The traits block keeps `additionalProperties: false` so unknown
+    # user-editable fields are rejected at the boundary. `picture` is
+    # added as an optional URI for the SPA avatar slot.
+    #
+    # `metadata_admin` is shown for documentation purposes. Kratos does
+    # NOT validate metadata against the identity schema (see
+    # https://www.ory.sh/docs/kratos/manage-identities/managing-users-identities-metadata)
+    # — the structure is enforced by jinbe at the admin API boundary.
+    # `organizations` is the array of organization UUIDs the identity
+    # may act in for authorization purposes (Path 3 hybrid: the legacy
+    # single `organization_id` trait remains primary for billing /
+    # employment semantics; this array is additive and drives authz).
     identitySchemas:
       person.schema.json: |
         {
@@ -212,10 +225,31 @@ kratos:
                     "recovery": { "via": "email" }
                   }
                 },
-                "name": { "type": "string", "title": "Name" }
+                "name": { "type": "string", "title": "Name" },
+                "picture": {
+                  "type": "string",
+                  "format": "uri",
+                  "title": "Avatar URL"
+                }
               },
               "required": ["email"],
               "additionalProperties": false
+            },
+            "metadata_admin": {
+              "type": "object",
+              "properties": {
+                "organizations": {
+                  "type": "array",
+                  "title": "Organization memberships",
+                  "description": "List of organization UUIDs the identity belongs to. Authoritative for authorization (rbac.user_in_org). The legacy traits.organization_id, if present in a tenant schema, remains the primary single-org pointer for billing/employment semantics.",
+                  "items": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "uniqueItems": true,
+                  "default": []
+                }
+              }
             }
           }
         }


### PR DESCRIPTION
## Summary

- Rename the in-chart error-page resources (`ConfigMap`, `Deployment`, `Service`) to `<release>-error-page` so two `auth` releases can be installed into the same namespace without colliding on a global Service name.
- Move the oathkeeper proxy `Ingress` into the parent chart (vendored from upstream Ory oathkeeper 0.61.0 `templates/ingress-proxy.yaml`) so annotation values get a real `tpl` pass and the `default-backend` annotation can reference `{{ .Release.Name }}`.
- Force the subchart's Ingress emission off (`oathkeeper.ingress.proxy.enabled: false`) and read parent-owned ingress config from a new top-level key `oathkeeperProxyIngress:` whose schema mirrors the subchart's `ingress.proxy.*` 1:1.
- Bump `Chart.yaml` to `0.7.3` (next available after the two PRs already on `main`).
- Migrate the example overlay (`examples/example-org-values.yaml`) to the new key path; add a comment block in `values.yaml` documenting why the subchart's Ingress is forced off and how overlays should migrate.

## Why

The subchart renders its Ingress annotations with bare `toYaml`, no `tpl` wrapper. That meant the `default-backend` annotation value had to be a plain string — the chart was forced to use a globally-named `error-page` Service so the literal annotation worked under any release name. Two releases of `auth` in the same namespace would collide on that name.

Moving the Ingress to the parent template lets us put `{{ .Release.Name }}-error-page` in the annotation value and have it resolved at install time, which unblocks the rename of every error-page resource.

Companion to a stage-2 multi-org change that will land on the same branch.

## Verification

- `helm lint charts/auth` clean.
- Two-release render confirms distinct prefixed names with no collision:
  ```
  $ helm template alpha charts/auth -f /tmp/min-values.yaml | yq '...' => "alpha-error-page"
  $ helm template bravo charts/auth -f /tmp/min-values.yaml | yq '...' => "bravo-error-page"
  ```
- Annotation rendering confirms the `tpl` pass works:
  ```
  $ helm template alpha charts/auth ... | grep default-backend
  nginx.ingress.kubernetes.io/default-backend: 'alpha-error-page'
  ```
- Single Ingress per release (not duplicate): `yq 'select(.kind=="Ingress") | .metadata.name' | sort | uniq -c` returns exactly one entry per release name.
- Example overlay renders clean: hosts, CORS allow-origin override, and `ingressClassName: nginx` all preserved.
- Deployment selector / Service selector / pod labels all still match (labels come from `auth.selectorLabels` which is release-driven, not name-driven).

## Migration notes for overlays

Overlays that previously set `oathkeeper.ingress.proxy.*` MUST rename that top-level key to `oathkeeperProxyIngress:`. The inner schema (`annotations`, `className`, `hosts`, `tls`, `defaultBackend`) is unchanged.

The chart's `values.yaml` now hard-sets `oathkeeper.ingress.proxy.enabled: false` and `oathkeeper.ingress.api.enabled: false`. Flipping either back to `true` in an overlay will emit a duplicate Ingress (same name) and `helm install` will fail with a manifest conflict — intentional fail-closed behaviour to surface accidental re-enabling.

## Subchart fork hygiene

The new file `templates/oathkeeper/ingress-proxy.yaml` starts with a comment that names the upstream source (oathkeeper 0.61.0) and instructs any future bumper to diff against the new upstream `templates/ingress-proxy.yaml` and re-apply.

## Test plan

- [ ] CI green
- [ ] Optional smoke install on a non-prod test namespace, confirm:
  - exactly one Ingress per release with name `<release>-oathkeeper-proxy`
  - error-page Service named `<release>-error-page`
  - hitting a forbidden path returns the styled 403 page (custom-http-errors reroute reaches the prefixed Service)
- [ ] Pin downstream ArgoCD apps to `0.7.3` only after merge.

## Scope

Stage 1 of a multi-stage refactor on the same branch. Stage 2 will land additional chart-side changes on top — do not merge until that lands.