### PR TITLE
fix(app): disable linkerd injection on namespace label/annotate hooks

### DIFF
--- a/charts/app/Chart.yaml
+++ b/charts/app/Chart.yaml
@@ -17,4 +17,4 @@ dependencies:
   version: ">=0.2.1"
   repository: https://charts.w6d.io
 appVersion: v3.1.5
-version: 3.1.5
+version: 3.1.6

--- a/charts/app/templates/namespace/_jobspec_ns_annotate.yaml
+++ b/charts/app/templates/namespace/_jobspec_ns_annotate.yaml
@@ -14,6 +14,9 @@ spec:
   completions: 1
   parallelism: 1
   template:
+    metadata:
+      annotations:
+        linkerd.io/inject: disabled
     spec:
       serviceAccountName: {{ include "app.serviceAccountName" . }}-ns
       containers:

--- a/charts/app/templates/namespace/_jobspec_ns_label.yaml
+++ b/charts/app/templates/namespace/_jobspec_ns_label.yaml
@@ -14,6 +14,9 @@ spec:
   completions: 1
   parallelism: 1
   template:
+    metadata:
+      annotations:
+        linkerd.io/inject: disabled
     spec:
       serviceAccountName: {{ include "app.serviceAccountName" . }}-ns
       containers:


### PR DESCRIPTION
## Summary

The pre-install/pre-upgrade hook Jobs `label-ns` / `annotate-ns` run a one-shot `kubectl label/annotate ns` then exit. When the target namespace has Linkerd injection enabled and `proxy.nativeSidecar` is false, the injected `linkerd-proxy` sidecar never terminates after the main container exits, so:

- the pod never reaches a terminal phase,
- the Job never becomes `Succeeded`,
- `helm.sh/hook-delete-policy: hook-succeeded` never fires,
- ArgoCD/Helm re-runs the hook on every sync (because the hook never completes).

Combined with a unique random suffix in the Job name (`label-ns-{{ randAlphaNum 5 }}`), each retry creates a brand-new Job rather than replacing the previous one, so the Jobs accumulate without bound and eventually saturate node pod capacity (`Too many pods` cluster-wide).

These ephemeral kubectl-label/annotate jobs have no need for the mesh, so they are opted out with `linkerd.io/inject: disabled` on the pod template.

## Changes

- `charts/app/templates/namespace/_jobspec_ns_label.yaml` — add `linkerd.io/inject: disabled` on the pod template
- `charts/app/templates/namespace/_jobspec_ns_annotate.yaml` — same
- `charts/app/Chart.yaml` — bump chart `version` 3.1.5 → 3.1.6

## Test plan

- [x] `helm template` of `charts/app` with `namespaceLabels`/`namespaceAnnotations` set renders the Job with the new annotation in `spec.template.metadata.annotations`
- [x] Reproduced the failure mode on a real dev cluster (EKS 1.34, Linkerd with `nativeSidecar: false`) — Jobs accumulated to ~11k, nodes hit 300/pod limit
- [ ] After deploy of `app@3.1.6` + service repackage: hook Job reaches `Succeeded` and is cleaned up by `hook-delete-policy`

## Notes

- This is the targeted fix for the hook lifecycle. The broader question — whether to re-enable `nativeSidecar` (which would make all meshed Jobs terminate cleanly) versus keeping it disabled to avoid the k8s 1.34 admission issue from Linkerd edge-26.5.2 — is outside the scope of this PR.