### PR TITLE
fix(app): render linkerd Server apiVersion by cluster capability (v1beta3/v1beta1)

### DIFF
--- a/charts/app/Chart.yaml
+++ b/charts/app/Chart.yaml
@@ -17,4 +17,4 @@ dependencies:
   version: ">=0.2.1"
   repository: https://charts.w6d.io
 appVersion: v3.1.5
-version: 3.1.6
+version: 3.1.7

--- a/charts/app/templates/linkerd/policy.yaml
+++ b/charts/app/templates/linkerd/policy.yaml
@@ -12,7 +12,11 @@
 {{- /* Server resources — one per port */ -}}
 {{- range $p := $ports }}
 ---
+{{- if $.Capabilities.APIVersions.Has "policy.linkerd.io/v1beta3" }}
 apiVersion: policy.linkerd.io/v1beta3
+{{- else }}
+apiVersion: policy.linkerd.io/v1beta1
+{{- end }}
 kind: Server
 metadata:
   name: {{ $fullname }}-server{{ if not $singlePort }}-{{ $p.port }}{{ end }}
@@ -24,7 +28,9 @@ spec:
       {{- include "helper.labels.matchLabels" $ | nindent 6 }}
   port: {{ $p.port }}
   proxyProtocol: {{ default "unknown" $p.proxyProtocol }}
+{{- if $.Capabilities.APIVersions.Has "policy.linkerd.io/v1beta3" }}
   accessPolicy: {{ if $hasCommunications }}deny{{ else }}audit{{ end }}
+{{- end }}
 {{- end }}
 {{- if $hasCommunications }}
 {{- /* MeshTLSAuthentication — one per comm (shared across ports) */ -}}


### PR DESCRIPTION
## Problème
Le `Server` Linkerd du chart `app` est figé en `policy.linkerd.io/v1beta3` (ajouté en 3.1.3, dormant). Sur **qualif** (Linkerd **2.14**, CRD `Server` max **v1beta1**), cette version n'est pas servie → ArgoCD échoue le sync (`Server.policy.linkerd.io "" not found`) et **bloque tous les services meshés** (15 apps `time-backend-*` OutOfSync). dev/prod (edge-25, v1beta3) ne sont pas affectés.

Déclenché par le repackage du 02/06 (bump CHART_VERSION → app 3.1.6) qui a embarqué ce template dans `time`.

## Fix
Rend l'apiVersion du `Server` selon les capabilities du cluster cible :
- `v1beta3` là où elle est servie (dev/prod edge-25),
- `v1beta1` sinon (qualif Linkerd 2.14).

`accessPolicy` est aussi gardé derrière la même condition (champ absent du schema v1beta1).

Auto-adaptatif, aucune config par env. Audit du chart : le `Server` est le **seul** objet concerné (MeshTLS/AuthZ en v1alpha1 et HTTPRoute en Gateway API sont servis partout).

## Validation
`helm template --api-versions` :
- qualif (v1beta1) → Server `v1beta1`, pas d'accessPolicy ✅
- prod (v1beta3) → Server `v1beta3` + accessPolicy ✅

Chart `app` 3.1.6 → 3.1.7.