### PR TITLE
fix(app): scope linkerd Server capability check to the Server kind

### DIFF
--- a/charts/app/Chart.yaml
+++ b/charts/app/Chart.yaml
@@ -17,4 +17,4 @@ dependencies:
   version: ">=0.2.1"
   repository: https://charts.w6d.io
 appVersion: v3.1.5
-version: 3.1.7
+version: 3.1.8

--- a/charts/app/templates/linkerd/policy.yaml
+++ b/charts/app/templates/linkerd/policy.yaml
@@ -12,7 +12,7 @@
 {{- /* Server resources — one per port */ -}}
 {{- range $p := $ports }}
 ---
-{{- if $.Capabilities.APIVersions.Has "policy.linkerd.io/v1beta3" }}
+{{- if $.Capabilities.APIVersions.Has "policy.linkerd.io/v1beta3/Server" }}
 apiVersion: policy.linkerd.io/v1beta3
 {{- else }}
 apiVersion: policy.linkerd.io/v1beta1
@@ -28,7 +28,7 @@ spec:
       {{- include "helper.labels.matchLabels" $ | nindent 6 }}
   port: {{ $p.port }}
   proxyProtocol: {{ default "unknown" $p.proxyProtocol }}
-{{- if $.Capabilities.APIVersions.Has "policy.linkerd.io/v1beta3" }}
+{{- if $.Capabilities.APIVersions.Has "policy.linkerd.io/v1beta3/Server" }}
   accessPolicy: {{ if $hasCommunications }}deny{{ else }}audit{{ end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
## Problème
Suite de #161. Le check capability `policy.linkerd.io/v1beta3` est au niveau **groupe/version** : il est vrai dès qu'**une** CRD du groupe sert v1beta3. Sur qualif (Linkerd 2.14), `httproutes.policy.linkerd.io` sert v1beta3 alors que `servers` ne va que jusqu'à v1beta1 → le check renvoyait `true` → `Server` rendu en v1beta3 **non servi pour ce kind** → sync ArgoCD KO (`Server.policy.linkerd.io "" not found`).

## Fix
Check resserré au **kind** : `policy.linkerd.io/v1beta3/Server`.
- qualif : Server absent en v1beta3 → `false` → v1beta1 (sans accessPolicy) ✅
- dev/prod (edge-25) : Server servi en v1beta3 → `true` → v1beta3 + accessPolicy ✅ (aucun downgrade)

ArgoCD (v2.13.2 ici) passe les api-versions au niveau kind, donc le check est résolu correctement par cluster.

## Validation (helm template --api-versions)
- qualif (groupe v1beta3 via HTTPRoute, Server en v1beta1) → Server `v1beta1`, accessPolicy absent ✅
- prod (Server v1beta3) → Server `v1beta3` + accessPolicy ✅

Chart `app` 3.1.7 → 3.1.8.