### PR TITLE
feat(app): add workload.enabled and service.enabled guards (3.1.10)

### DIFF
--- a/charts/app/Chart.yaml
+++ b/charts/app/Chart.yaml
@@ -17,4 +17,4 @@ dependencies:
   version: ">=0.2.1"
   repository: https://charts.w6d.io
 appVersion: v3.1.9
-version: 3.1.9
+version: 3.1.10

--- a/charts/app/templates/svc.yaml
+++ b/charts/app/templates/svc.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.service.enabled }}
 {{- $serviceName := ((include "helper.names.service" (dict "name" .Values.service.name "context" $)) | lower ) }}
 ---
 apiVersion: v1
@@ -41,3 +42,4 @@ spec:
   type: {{ default "ClusterIP" .Values.service.type }}
   selector:
     {{- include "helper.labels.matchLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/app/templates/workload.yaml
+++ b/charts/app/templates/workload.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.workload.enabled }}
 {{- $image := (include "helper.images.image" ( dict "imageRoot" .Values.image ) ) }}
 {{- $volumes := list }}
 {{- if .Values.lifecycle.enabled }}
@@ -195,3 +196,4 @@ spec:
   {{-   end }}
   {{-   include "helper.volumes.volumeClaimTemplates" (dict "volumes" $volumes) | nindent 2 }}
   {{- end }}
+{{- end }}

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -8,6 +8,11 @@ namespace: ""
 
 kind: ""
 
+# Main workload (Deployment/StatefulSet/DaemonSet/Job from `kind`).
+# Disable to render only extraResources (e.g. CronJob-only deployments).
+workload:
+  enabled: true
+
 database:
   host: ""
   adminpassword: ""
@@ -63,6 +68,7 @@ lifecycle:
 resources: {}
 
 service:
+  enabled: true
   name: "-"
   internalPort: 8080
   externalPort: 8080

--- a/charts/auth/Chart.lock
+++ b/charts/auth/Chart.lock
@@ -5,11 +5,14 @@ dependencies:
 - name: oathkeeper
   repository: https://k8s.ory.sh/helm/charts
   version: 0.61.0
+- name: hydra
+  repository: https://k8s.ory.sh/helm/charts
+  version: 0.62.1
 - name: opal
   repository: file://charts/opal
   version: 0.0.29
 - name: redis
   repository: https://charts.bitnami.com/bitnami
   version: 19.6.4
-digest: sha256:76c3b5a174d4d0d97213dcfd45a8a34f725426f8df2510dead4364de1fbf99fb
-generated: "2026-04-24T09:44:51.398910813+02:00"
+digest: sha256:8a82f3bbf36eb80ed602f64612583e05568516f7ed437276df685d3f64856a9b
+generated: "2026-06-09T16:14:38.767165+02:00"

--- a/charts/auth/Chart.yaml
+++ b/charts/auth/Chart.yaml
@@ -2,12 +2,13 @@ apiVersion: v2
 name: auth
 description: Complete authentication stack with Kratos, Oathkeeper, OPAL, Jinbe, and Redis
 type: application
-version: 0.7.5
+version: 0.8.0
 appVersion: "0.5.1"
 keywords:
   - auth
   - kratos
   - oathkeeper
+  - hydra
   - opal
   - opa
   - jinbe
@@ -34,6 +35,13 @@ dependencies:
     version: "0.61.0"
     repository: https://k8s.ory.sh/helm/charts
     condition: oathkeeper.enabled
+
+  # Hydra - OAuth2 / OpenID Connect server (M2M client_credentials API keys)
+  # Opt-in: disabled by default so existing consumers are unaffected.
+  - name: hydra
+    version: "0.62.1"
+    repository: https://k8s.ory.sh/helm/charts
+    condition: hydra.enabled
 
   # OPAL - Policy Administration (Server + Client + OPA)
   # Vendored for custom template modifications (podAnnotations for Vault)

--- a/charts/auth/values.yaml
+++ b/charts/auth/values.yaml
@@ -395,6 +395,48 @@ oathkeeper:
   accessRules: ""
 
 # =============================================================================
+# Hydra - OAuth2 / OpenID Connect server (M2M client_credentials API keys)
+# =============================================================================
+# Opt-in. Disabled by default so existing consumers are unaffected. When
+# enabled, Hydra issues OAuth2 clients used as scoped, per-organization API
+# keys (grant_type=client_credentials). It MUST use its own database (do NOT
+# share the Kratos schema). Provide DSN + secrets via your environment overlay
+# (e.g. Vault), the same way Kratos is wired.
+#
+#   - secrets.system / DSN: inject via hydra.deployment.extraEnv referencing
+#     your secret store (e.g. value: vault:infra/data/auth#hydra-dsn).
+#   - Access-token strategy: 'opaque' is recommended so deleting a client
+#     revokes access on next introspection. Use 'jwt' only with short TTLs.
+hydra:
+  enabled: false
+
+  # maester reconciles OAuth2Client CRDs; not needed when clients are created
+  # via the Admin API by the customer-area backend. Disabled to reduce surface.
+  maester:
+    enabled: false
+
+  hydra:
+    automigration:
+      enabled: true
+    config:
+      # dsn and secrets.system are intentionally empty here; supply them via
+      # the environment overlay (extraEnv -> Vault) so they are never committed.
+      dsn: ""
+      secrets: {}
+      urls:
+        self:
+          issuer: ""
+      oauth2:
+        expose_internal_errors: false
+      strategies:
+        access_token: opaque
+      ttl:
+        access_token: 15m
+      log:
+        level: info
+        format: json
+
+# =============================================================================
 # OPAL - Policy Administration (Permit.io)
 # =============================================================================
 opal:


### PR DESCRIPTION
Guard the main workload (workload.yaml) and Service (svc.yaml), both defaulting to true so existing consumers are unaffected. Enables rendering only `extraResources` (e.g. CronJob-only deployments) via `workload.enabled=false` + `service.enabled=false`. Chart bumped to 3.1.10.

Verified with `helm template`: defaults still render Deployment+Service; with both disabled, neither renders.