### PR TITLE
feat(app): optional bundled postgresql dependency (3.1.11)

### DIFF
--- a/charts/app/Chart.lock
+++ b/charts/app/Chart.lock
@@ -2,5 +2,8 @@ dependencies:
 - name: helper
   repository: https://charts.w6d.io
   version: 0.2.1
-digest: sha256:94ae0be617e0a4ed46c6d65070bd6d8a085e76c8a102fc52ba4396f60d6b8488
-generated: "2025-07-31T15:46:45.925337+02:00"
+- name: postgresql
+  repository: https://charts.bitnami.com/bitnami
+  version: 15.5.38
+digest: sha256:91138142d5c87c3a76732c9ca749bbffc6bba2b38bcc0a01c49ffbd872948c1f
+generated: "2026-06-11T11:37:45.610885+02:00"

--- a/charts/app/Chart.yaml
+++ b/charts/app/Chart.yaml
@@ -16,5 +16,11 @@ dependencies:
 - name: helper
   version: ">=0.2.1"
   repository: https://charts.w6d.io
+# PostgreSQL - optional bundled database (opt-in; disabled by default so
+# existing consumers are unaffected). Enable with postgresql.enabled=true.
+- name: postgresql
+  version: "15.5.38"
+  repository: https://charts.bitnami.com/bitnami
+  condition: postgresql.enabled
 appVersion: v3.1.9
-version: 3.1.10
+version: 3.1.11

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -13,6 +13,12 @@ kind: ""
 workload:
   enabled: true
 
+# Optional bundled PostgreSQL (bitnami subchart). Disabled by default; enable
+# and configure under this key to deploy a database alongside (or instead of)
+# the app workload. See https://github.com/bitnami/charts/tree/main/bitnami/postgresql
+postgresql:
+  enabled: false
+
 database:
   host: ""
   adminpassword: ""


### PR DESCRIPTION
Adds bitnami/postgresql 15.5.38 (PG 16.4) as a conditional dependency (`condition: postgresql.enabled`, default **false**). Lets an app release bundle a database (used for the fleet-automation qualif Postgres). Backward-compatible: default renders no postgres objects; `postgresql.enabled=true` renders the StatefulSet (verified via `helm template`).