### PR TITLE
feat(auth): opa-authz-proxy v0.4.0 + optional branded courier emails

### DIFF
--- a/charts/auth/Chart.yaml
+++ b/charts/auth/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: auth
 description: Complete authentication stack with Kratos, Oathkeeper, OPAL, Jinbe, and Redis
 type: application
-version: 0.8.5
+version: 0.9.0
 appVersion: "0.7.0"
 keywords:
   - auth

--- a/charts/auth/README.md
+++ b/charts/auth/README.md
@@ -203,9 +203,9 @@ jinbe:
   podAnnotations:
     vault.security.banzaicloud.io/vault-addr: "http://vault.vault:8200"
     vault.security.banzaicloud.io/vault-role: "auth"
-    vault.security.banzaicloud.io/vault-env-from-path: "infra/data/auth"
+    vault.security.banzaicloud.io/vault-env-from-path: "secret/data/myapp"
   env:
-    ENCRYPTION_KEY: "vault:infra/data/auth#ENCRYPTION_KEY"
+    ENCRYPTION_KEY: "vault:secret/data/myapp#ENCRYPTION_KEY"
 ```
 
 ## Adding a New Service

--- a/charts/auth/files/email/code.body.html
+++ b/charts/auth/files/email/code.body.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <style>
+        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #333; margin: 0; padding: 0; background-color: #f5f5f5; }
+        .container { max-width: 600px; margin: 0 auto; padding: 20px; }
+        .card { background-color: #fff; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); overflow: hidden; }
+        .header { text-align: center; padding: 0; }
+        .content { padding: 32px 24px; }
+        .code { font-size: 24px; font-weight: bold; letter-spacing: 4px; text-align: center; padding: 16px; background-color: #f5f5f5; border-radius: 4px; }
+        .footer { text-align: center; padding: 16px; color: #898D96; font-size: 12px; background-color: #fafafa; border-top: 1px solid #eee; }
+        .footer a { color: #666; text-decoration: none; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="card">
+            <div class="header">HEADER_BLOCK</div>
+            <div class="content">
+                <p>Bonjour,</p>
+                <p>INTRO_TOKEN</p>
+                <p class="code">CODE_TOKEN</p>
+                <p>Ce code expirera dans 15 minutes.</p>
+                <p style="color: #666; font-size: 14px;"><strong>Important :</strong> BRAND_NAME ne vous appellera jamais pour vous demander ce code.</p>
+                <p>Cordialement,<br>L'équipe BRAND_NAME</p>
+            </div>
+            <div class="footer">
+                Besoin d'aide ? <a href="mailto:SUPPORT_EMAIL">SUPPORT_EMAIL</a>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/charts/auth/files/email/code.body.txt
+++ b/charts/auth/files/email/code.body.txt
@@ -1,0 +1,12 @@
+Bonjour,
+
+INTRO_TOKEN CODE_TOKEN
+
+Ce code expirera dans 15 minutes.
+
+Important : BRAND_NAME ne vous appellera jamais pour vous demander ce code.
+
+Cordialement,
+L'équipe BRAND_NAME
+
+Besoin d'aide ? SUPPORT_EMAIL

--- a/charts/auth/files/email/message.body.html
+++ b/charts/auth/files/email/message.body.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <style>
+        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #333; margin: 0; padding: 0; background-color: #f5f5f5; }
+        .container { max-width: 600px; margin: 0 auto; padding: 20px; }
+        .card { background-color: #fff; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); overflow: hidden; }
+        .header { text-align: center; padding: 0; }
+        .content { padding: 32px 24px; }
+        .footer { text-align: center; padding: 16px; color: #898D96; font-size: 12px; background-color: #fafafa; border-top: 1px solid #eee; }
+        .footer a { color: #666; text-decoration: none; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="card">
+            <div class="header">HEADER_BLOCK</div>
+            <div class="content">
+                <p>Bonjour,</p>
+                <p>INTRO_TOKEN</p>
+                <p>Cordialement,<br>L'équipe BRAND_NAME</p>
+            </div>
+            <div class="footer">
+                Besoin d'aide ? <a href="mailto:SUPPORT_EMAIL">SUPPORT_EMAIL</a>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/charts/auth/files/email/message.body.txt
+++ b/charts/auth/files/email/message.body.txt
@@ -1,0 +1,8 @@
+Bonjour,
+
+INTRO_TOKEN
+
+Cordialement,
+L'équipe BRAND_NAME
+
+Besoin d'aide ? SUPPORT_EMAIL

--- a/charts/auth/templates/kratos/email-templates.yaml
+++ b/charts/auth/templates/kratos/email-templates.yaml
@@ -1,0 +1,124 @@
+{{- /*
+Branded Kratos courier templates for every enabled email flow.
+
+Each rendered ConfigMap holds the three files Kratos expects under a
+template_override_path:
+    email.subject.gotmpl / email.body.gotmpl / email.body.plaintext.gotmpl
+
+Two families are rendered:
+
+  Code flows (login_code, registration_code, recovery_code, verification_code),
+  status "valid", from files/email/code.body.* — these carry a one-time code.
+
+  No-code flows (recovery_code/invalid, verification_code/invalid,
+  verifiable_address_changed), from files/email/message.body.* — notices with no
+  code (attempt on an unregistered/again address, or address-changed alert).
+
+The HTML/text bodies live as version-controlled files under files/email/ and are
+rendered here with these substitutions. All branding is injected from values at
+render time so this chart carries no environment-specific identifiers and is safe
+to publish; the bodies keep only generic copy + tokens.
+
+  HEADER_BLOCK  -> an <img> banner when authEmail.bannerUrl is set, else a text
+                   title (so the email still renders if no banner URL is given).
+  INTRO_TOKEN   -> the per-flow lead-in sentence, so each flow reads correctly
+                   (e.g. recovery says "récupération", the address-changed notice
+                   describes the change). May itself contain BRAND_NAME /
+                   SUPPORT_EMAIL tokens, which are substituted after it is inlined.
+  CODE_TOKEN    -> (code flows only) the Kratos Go-template variable for that flow
+                   ({{ .LoginCode }} / {{ .RegistrationCode }} / {{ .RecoveryCode }}
+                   / {{ .VerificationCode }}), built without a literal "{{" so Helm
+                   does not try to evaluate it here.
+  BRAND_NAME    -> authEmail.brandName
+  SUPPORT_EMAIL -> authEmail.supportEmail
+
+Subject is per-flow by default. authEmail.subject, if non-empty, overrides the
+subject for every flow (single global subject escape hatch).
+
+Wiring (set in the deployed values overlay, NOT here, so the chart is safe by
+default): kratos.kratos.config.courier.template_override_path=/conf/courier-templates
+and kratos.statefulSet / kratos.deployment extraVolumes+extraVolumeMounts to mount
+each ConfigMap at /conf/courier-templates/<type>/<status> (or, for the address
+changed notice, /conf/courier-templates/verifiable_address_changed). Disabled ->
+no ConfigMaps, Kratos defaults.
+*/}}
+{{- if .Values.authEmail.enabled }}
+{{- $lb := "{" }}
+{{- $rb := "}" }}
+{{- $codeHtml := .Files.Get "files/email/code.body.html" }}
+{{- $codeText := .Files.Get "files/email/code.body.txt" }}
+{{- $msgHtml := .Files.Get "files/email/message.body.html" }}
+{{- $msgText := .Files.Get "files/email/message.body.txt" }}
+{{- $banner := .Values.authEmail.bannerUrl | default "" }}
+{{- $brand := .Values.authEmail.brandName | default "" }}
+{{- $support := .Values.authEmail.supportEmail | default "" }}
+{{- $subjectOverride := .Values.authEmail.subject | default "" }}
+{{- $header := "" }}
+{{- if $banner }}
+{{-   $header = printf "<img src=\"%s\" alt=\"%s\" width=\"100%%\" style=\"display:block;\">" $banner $brand }}
+{{- else }}
+{{-   $header = printf "<div style=\"padding:24px 0;text-align:center;font-size:22px;font-weight:600;color:#4C6FE7;\">%s</div>" $brand }}
+{{- end }}
+{{- /* ---- Code flows (status "valid"): one ConfigMap per code type ---- */}}
+{{- $loginVar := printf "%s%s .LoginCode %s%s" $lb $lb $rb $rb }}
+{{- $registrationVar := printf "%s%s .RegistrationCode %s%s" $lb $lb $rb $rb }}
+{{- $recoveryVar := printf "%s%s .RecoveryCode %s%s" $lb $lb $rb $rb }}
+{{- $verificationVar := printf "%s%s .VerificationCode %s%s" $lb $lb $rb $rb }}
+{{- $codes := dict "login_code" $loginVar "registration_code" $registrationVar "recovery_code" $recoveryVar "verification_code" $verificationVar }}
+{{- $intros := dict "login_code" "Votre code de connexion pour BRAND_NAME est :" "registration_code" "Bienvenue ! Votre code d'inscription pour BRAND_NAME est :" "recovery_code" "Votre code de récupération pour BRAND_NAME est :" "verification_code" "Votre code de vérification pour BRAND_NAME est :" }}
+{{- $subjects := dict "login_code" "Votre code de connexion BRAND_NAME" "registration_code" "Bienvenue sur BRAND_NAME — votre code" "recovery_code" "Votre code de récupération BRAND_NAME" "verification_code" "Votre code de vérification BRAND_NAME" }}
+{{- range $type, $codeVar := $codes }}
+{{- $intro := index $intros $type }}
+{{- $subject := $subjectOverride }}
+{{- if not $subject }}{{ $subject = index $subjects $type }}{{ end }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $.Release.Name }}-email-{{ $type | kebabcase }}-valid
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "auth.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: kratos-email
+data:
+  "email.subject.gotmpl": |-
+    {{- $subject | replace "BRAND_NAME" $brand | nindent 4 }}
+  "email.body.gotmpl": |-
+    {{- $codeHtml | replace "HEADER_BLOCK" $header | replace "INTRO_TOKEN" $intro | replace "CODE_TOKEN" $codeVar | replace "BRAND_NAME" $brand | replace "SUPPORT_EMAIL" $support | nindent 4 }}
+  "email.body.plaintext.gotmpl": |-
+    {{- $codeText | replace "INTRO_TOKEN" $intro | replace "CODE_TOKEN" $codeVar | replace "BRAND_NAME" $brand | replace "SUPPORT_EMAIL" $support | nindent 4 }}
+{{- end }}
+{{- /* ---- No-code flows: recovery/verification "invalid" + verifiable address changed ---- */}}
+{{- $noCode := list
+    (dict "name" "recovery-code-invalid"
+          "subject" "Tentative de récupération de compte"
+          "intro" "Quelqu'un (peut-être vous) a demandé la récupération d'un compte associé à cette adresse e-mail, mais aucun compte n'y est enregistré. Si c'était vous, vérifiez que vous avez utilisé la bonne adresse ; sinon, vous pouvez ignorer cet e-mail en toute sécurité.")
+    (dict "name" "verification-code-invalid"
+          "subject" "Tentative de vérification d'adresse"
+          "intro" "Quelqu'un (peut-être vous) a tenté de vérifier cette adresse e-mail, mais aucun compte n'y est enregistré. Si c'était vous, vérifiez que vous avez utilisé la bonne adresse ; sinon, vous pouvez ignorer cet e-mail.")
+    (dict "name" "verifiable-address-changed"
+          "subject" "Votre adresse e-mail a été modifiée"
+          "intro" "L'adresse e-mail de votre compte BRAND_NAME vient d'être modifiée. Si vous êtes à l'origine de ce changement, aucune action n'est nécessaire. Sinon, contactez immédiatement SUPPORT_EMAIL.")
+}}
+{{- range $flow := $noCode }}
+{{- $intro := $flow.intro }}
+{{- $subject := $subjectOverride }}
+{{- if not $subject }}{{ $subject = $flow.subject }}{{ end }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $.Release.Name }}-email-{{ $flow.name }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "auth.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: kratos-email
+data:
+  "email.subject.gotmpl": |-
+    {{- $subject | replace "BRAND_NAME" $brand | replace "SUPPORT_EMAIL" $support | nindent 4 }}
+  "email.body.gotmpl": |-
+    {{- $msgHtml | replace "HEADER_BLOCK" $header | replace "INTRO_TOKEN" $intro | replace "BRAND_NAME" $brand | replace "SUPPORT_EMAIL" $support | nindent 4 }}
+  "email.body.plaintext.gotmpl": |-
+    {{- $msgText | replace "INTRO_TOKEN" $intro | replace "BRAND_NAME" $brand | replace "SUPPORT_EMAIL" $support | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/charts/auth/values.yaml
+++ b/charts/auth/values.yaml
@@ -221,6 +221,41 @@ kratos:
         }
 
 # =============================================================================
+# authEmail - branded Kratos courier code emails (recovery + verification)
+# =============================================================================
+# Renders templates/kratos/email-templates.yaml into per-type ConfigMaps that
+# Kratos mounts as courier template overrides. Disabled by default: leaving this
+# off means Kratos uses its built-in default emails (safe, no ConfigMaps).
+#
+# To ENABLE in a values overlay you must set THREE things together (kept in the
+# overlay, not here, so the chart is inert by default):
+#   1. authEmail.enabled: true (+ bannerUrl / brandName / subject below)
+#   2. kratos.kratos.config.courier.template_override_path: /conf/courier-templates
+#   3. kratos.statefulSet.extraVolumes + extraVolumeMounts mounting each
+#      ConfigMap ({release}-email-recovery-code-valid / -verification-code-valid)
+#      at /conf/courier-templates/<recovery_code|verification_code>/valid
+authEmail:
+  # Renders branded Kratos courier templates as ConfigMaps for all seven flows:
+  # login/registration/recovery/verification code-valid emails, the recovery /
+  # verification "invalid" notices, and the verifiable-address-changed alert.
+  # Mount them via kratos.statefulSet/deployment extraVolumes+extraVolumeMounts
+  # under courier.template_override_path. Disabled -> Kratos built-in defaults.
+  enabled: false
+  # Public https URL of the banner image. Must be reachable by the recipient's
+  # mail client (email clients block data: URIs). Empty -> a text brand header
+  # is used instead of an <img>.
+  bannerUrl: ""
+  # Brand name for the <img alt> / text-header fallback and body copy
+  # (replaces the BRAND_NAME token in the bodies).
+  brandName: ""
+  # Support contact email shown in the body/footer (replaces SUPPORT_EMAIL).
+  supportEmail: ""
+  # Optional single subject applied to every flow. Leave empty to use the
+  # per-flow subjects (e.g. "Votre code de connexion <brandName>", the
+  # address-changed alert has its own subject, etc.).
+  subject: ""
+
+# =============================================================================
 # Oathkeeper - API Gateway (Ory)
 # =============================================================================
 # helmTemplatedConfigEnabled allows {{ .Release.Name }} in oathkeeper.config.
@@ -404,7 +439,7 @@ oathkeeper:
 # (e.g. Vault), the same way Kratos is wired.
 #
 #   - secrets.system / DSN: inject via hydra.deployment.extraEnv referencing
-#     your secret store (e.g. value: vault:infra/data/auth#hydra-dsn).
+#     your secret store (e.g. value: vault:secret/data/myapp#hydra-dsn).
 #   - Access-token strategy: 'opaque' is recommended so deleting a client
 #     revokes access on next introspection. Use 'jwt' only with short TTLs.
 hydra:
@@ -620,12 +655,13 @@ opaAuthzProxy:
 
   image:
     repository: ghcr.io/w6d-io/infra/opa-authz-proxy
-    # v0.3.1 sticks to HTTP 403 on deny (oathkeeper's remote_json
-    # authorizer rejects any other status as an internal error). The
-    # rego's decision.reason still rides along as an `X-Authz-Reason`
-    # response header for upstreams that want to distinguish a
-    # route_map miss from a permission denial.
-    tag: "v0.3.1"
+    # v0.4.0 forwards X-Tenant-Id into the OPA input and emits an
+    # X-User-Organizations response header — DORMANT until a caller sends
+    # X-Tenant-Id (none do yet). Retains v0.3.1 behaviour: HTTP 403 on deny
+    # (oathkeeper's remote_json authorizer rejects any other status), and the
+    # rego's decision.reason rides along as an `X-Authz-Reason` header for
+    # upstreams that want to distinguish a route_map miss from a denial.
+    tag: "v0.4.0"
     pullPolicy: IfNotPresent
 
   # Auto-computed from opal client service if empty


### PR DESCRIPTION
## What
- Bump the **opa-authz-proxy** default image `v0.3.1` -> `v0.4.0` (forwards `X-Tenant-Id` into the OPA input + emits an `X-User-Organizations` response header; dormant until a caller sends the header).
- Add an optional **`authEmail`** feature: branded Kratos courier templates for all 7 flows (recovery/verification valid+invalid, login/registration code, address-changed). Branding (brand name, support email, banner, subject) is injected from values, so the chart ships with no environment-specific content.

## Safety / compat
- `authEmail.enabled` defaults **false** -> a fresh install renders no ConfigMaps and uses Kratos's built-in emails.
- Courier `template_override_path` + volume mounts are set in the deployment overlay, not the chart defaults.
- Chart `0.8.5` -> `0.9.0`.

Validated locally: `helm dependency build`, `helm lint`, `helm template`, server `--dry-run`, and diff-vs-live all green.
