### PR TITLE
chore(auth): bump chart to 0.9.1 — default images jinbe v0.8.0, kuma v2.9.0

### DIFF
--- a/charts/auth/Chart.yaml
+++ b/charts/auth/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: auth
 description: Complete authentication stack with Kratos, Oathkeeper, OPAL, Jinbe, and Redis
 type: application
-version: 0.9.0
+version: 0.9.1
 appVersion: "0.7.0"
 keywords:
   - auth

--- a/charts/auth/values.yaml
+++ b/charts/auth/values.yaml
@@ -542,7 +542,7 @@ jinbe:
   #   --set jinbe.image.tag=latest
   image:
     repository: ghcr.io/w6d-io/jinbe
-    tag: v0.7.0
+    tag: v0.8.0
     pullPolicy: IfNotPresent
 
   service:
@@ -831,7 +831,7 @@ adminUi:
   replicaCount: 1
   image:
     repository: ghcr.io/w6d-io/kuma
-    tag: v2.8.0
+    tag: v2.9.0
     pullPolicy: IfNotPresent
   env:
     NEXT_PUBLIC_API_URL: ""  # Auto: https://app.{domain}


### PR DESCRIPTION
Simple patch bump. Updates default component image tags to the latest released:

- jinbe: v0.7.0 → v0.8.0
- kuma: v2.8.0 → v2.9.0

No template or values-structure changes. OPAL policy source unchanged (defaults to the shared policy repo main). appVersion unchanged.