### PR TITLE
fix(auth): escape oathkeeper runtime templates + bump to 0.9.2

### DIFF
--- a/charts/auth/Chart.yaml
+++ b/charts/auth/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: auth
 description: Complete authentication stack with Kratos, Oathkeeper, OPAL, Jinbe, and Redis
 type: application
-version: 0.9.1
+version: 0.9.2
 appVersion: "0.7.0"
 keywords:
   - auth

--- a/charts/auth/values.yaml
+++ b/charts/auth/values.yaml
@@ -318,10 +318,10 @@ oathkeeper:
             payload: |
               {
                 "input": {
-                  "sub": "{{ print .Subject }}",
-                  "email": "{{ index .Extra.identity.traits "email" }}",
-                  "object": "{{ .MatchContext.URL.Path }}",
-                  "action": "{{ .MatchContext.Method }}"
+                  "sub": "{{ "{{" }} print .Subject {{ "}}" }}",
+                  "email": "{{ "{{" }} if .Extra.identity {{ "}}" }}{{ "{{" }} index .Extra.identity.traits "email" {{ "}}" }}{{ "{{" }} end {{ "}}" }}",
+                  "object": "{{ "{{" }} .MatchContext.URL.Path {{ "}}" }}",
+                  "action": "{{ "{{" }} .MatchContext.Method {{ "}}" }}"
                 }
               }
             forward_response_headers_to_upstream:
@@ -341,8 +341,8 @@ oathkeeper:
             # nil-safe so requests reaching this rule via the noop fallback
             # authenticator (no session) don't crash.
             headers:
-              x-user-id: '{{ print .Subject }}'
-              x-user-email: '{{ index .Extra.identity.traits "email" }}'
+              x-user-id: '{{ "{{" }} print .Subject {{ "}}" }}'
+              x-user-email: '{{ "{{" }} if .Extra.identity {{ "}}" }}{{ "{{" }} index .Extra.identity.traits "email" {{ "}}" }}{{ "{{" }} end {{ "}}" }}'
       errors:
         # `unauthorized` (no Kratos session) is the only error that
         # still triggers a cross-host redirect to the login page —


### PR DESCRIPTION
## Problem
The chart fails to `helm template`/`install` — `tpl` evaluates Oathkeeper's own Go-template directives (`.Subject`, `.Extra.identity.traits`, `.MatchContext`) in the oathkeeper access-rule config at render time and hits a nil pointer. The escaping that protected these was lost, so the config only shipped because the release CI packages (never renders) the chart.

## Fix
- Restore `{{ "{{" }} … {{ "}}" }}` escaping on all six runtime templates so they survive the tpl pass and reach oathkeeper intact for per-request evaluation.
- Nil-guard the identity-email references (remote_json payload + header mutator) so unauthenticated requests return a clean pass-through instead of a 500 in the authorizer.
- Bump chart 0.9.1 → 0.9.2.

Verified: `helm template` renders 50 docs, 0 nil-pointer; resolved config emits the correct literal, guarded Oathkeeper templates.