### PR TITLE
feat(auth): 0.9.4 — probe/resource hardening, NetworkPolicy fixes, opt-in redis auth, image bumps

### DIFF
--- a/charts/auth/Chart.yaml
+++ b/charts/auth/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: auth
 description: Complete authentication stack with Kratos, Oathkeeper, OPAL, Jinbe, and Redis
 type: application
-version: 0.9.3
-appVersion: "0.7.0"
+version: 0.9.4
+appVersion: "0.9.1"
 keywords:
   - auth
   - kratos

--- a/charts/auth/templates/NOTES.txt
+++ b/charts/auth/templates/NOTES.txt
@@ -6,7 +6,9 @@ Components:
   - Jinbe (RBAC API):      http://{{ include "auth.jinbe.fullname" . }}:{{ .Values.jinbe.service.port }}
   - OPA (Policy Engine):   http://{{ .Release.Name }}-opal-client:8181
   - Redis (Data Store):    redis://{{ .Release.Name }}-redis-master:6379
+{{- if .Values.kratosLoginUi.enabled }}
   - Login UI:              http://{{ include "auth.kratosLoginUi.fullname" . }}:80
+{{- end }}
 {{- if .Values.adminUi.enabled }}
   - Admin UI (Kuma):       http://{{ include "auth.fullname" . }}-admin-ui:{{ .Values.adminUi.service.port }}
 {{- end }}
@@ -18,7 +20,7 @@ Endpoints:
   - Permission Sim:     POST /api/admin/rbac/simulate
   - Audit Events:       GET /api/admin/audit/events
 
-First visit: Register at https://{{ include "auth.authDomain" . }}/register
+First visit: Register at https://{{ include "auth.authDomain" . }}/auth/registration
 First user gets super_admin access automatically.
 
 ──────────────────────────────────────────────────────────────────────
@@ -50,7 +52,7 @@ First-time setup checklist
 
 5. Set initial admin (only required on first install — marker absent)
    --set jinbe.env.ADMIN_EMAIL=admin@your.com
-   --set jinbe.env.ADMIN_PASSWORD="<≥12-char-password>"
+   --set jinbe.env.ADMIN_PASSWORD="<≥16-char-password>"
 
 The Bootstrap Job (auth-jinbe-bootstrap) runs once per Helm install/upgrade
 and is a no-op on subsequent runs (Redis marker rbac:bootstrap:state).

--- a/charts/auth/templates/_helpers.tpl
+++ b/charts/auth/templates/_helpers.tpl
@@ -149,12 +149,19 @@ app.kubernetes.io/component: jinbe
 {{- end }}
 
 {{/*
-Jinbe pod annotations — user-provided values + (when global.vault.enabled) the
-banzai vault injector annotations. Used by both the Deployment and the
-post-install Bootstrap Job so they share an identical Vault scope.
+Jinbe pod annotations — user-provided values (jinbe.podAnnotations) merged with
+the Banzai Cloud vault injector annotations (auth.vaultAnnotations) when
+global.vault.enabled. Merged as a dict so a key never appears twice; on a key
+collision the user's value wins. When vault is disabled auth.vaultAnnotations
+renders empty and fromYaml yields an empty dict, so only user values remain.
+Used by both the Deployment and the Bootstrap Job so they share an identical
+Vault scope.
 */}}
 {{- define "auth.jinbe.podAnnotations" -}}
-{{- with .Values.jinbe.podAnnotations -}}
+{{- $vault := (include "auth.vaultAnnotations" . | fromYaml) | default dict -}}
+{{- $user := .Values.jinbe.podAnnotations | default dict -}}
+{{- $merged := merge (deepCopy $user) $vault -}}
+{{- with $merged }}
 {{- toYaml . }}
 {{- end }}
 {{- end }}
@@ -180,8 +187,24 @@ Bootstrap-only env (ADMIN_EMAIL/PASSWORD/NAME) is gated by
   value: {{ .Values.jinbe.image.tag | default .Chart.AppVersion | quote }}
 - name: COMMIT_SHA
   value: {{ .Values.jinbe.env.COMMIT_SHA | default (.Values.jinbe.image.tag | default .Chart.AppVersion) | quote }}
+{{/*
+  Redis password: explicit jinbe.env.REDIS_PASSWORD wins; otherwise sourced
+  from redis.auth.password when the bundled redis has auth enabled. Emitted
+  BEFORE REDIS_URL so k8s $(REDIS_PASSWORD) expansion works inside the URL
+  (jinbe's ioredis also reads REDIS_PASSWORD directly, which takes precedence).
+*/}}
+{{- $redisPass := "" -}}
+{{- if .Values.jinbe.env.REDIS_PASSWORD -}}
+{{- $redisPass = .Values.jinbe.env.REDIS_PASSWORD -}}
+{{- else if and .Values.redis.enabled .Values.redis.auth.enabled -}}
+{{- $redisPass = (.Values.redis.auth.password | default "") -}}
+{{- end -}}
+{{- if $redisPass }}
+- name: REDIS_PASSWORD
+  value: {{ $redisPass | quote }}
+{{- end }}
 - name: REDIS_URL
-  value: {{ .Values.jinbe.env.REDIS_URL | default (printf "redis://%s-redis-master:6379" .Release.Name) | quote }}
+  value: {{ .Values.jinbe.env.REDIS_URL | default (printf "redis://%s%s-redis-master:6379" (ternary ":$(REDIS_PASSWORD)@" "" (ne $redisPass "")) .Release.Name) | quote }}
 - name: KRATOS_PUBLIC_URL
   value: {{ .Values.jinbe.env.KRATOS_PUBLIC_URL | default (printf "http://%s-kratos-public:80" .Release.Name) | quote }}
 - name: KRATOS_ADMIN_URL
@@ -290,9 +313,10 @@ App domain
 {{- end }}
 
 {{/*
-Backup S3 env for jinbe (main + bootstrap) — mirrors the backup CronJob's S3
-target so jinbe can list/restore snapshots and first-init can pull latest.json.
-Credentials come from the jinbe ServiceAccount's IRSA annotation (no static keys).
+Backup S3 env for jinbe (main + bootstrap). jinbe self-schedules the export
+(no external CronJob) and reads the same S3 target so it can list/restore
+snapshots and first-init can pull latest.json. Credentials come from the jinbe
+ServiceAccount's IRSA annotation (no static keys).
 */}}
 {{- define "auth.backup.env" -}}
 - name: BACKUP_ENABLED

--- a/charts/auth/templates/error-page/deployment.yaml
+++ b/charts/auth/templates/error-page/deployment.yaml
@@ -18,6 +18,10 @@ spec:
       labels:
         {{- include "auth.labels" . | nindent 8 }}
         app.kubernetes.io/component: error-page
+      annotations:
+        # Roll the pod when the branding/config ConfigMap changes so nginx
+        # picks up new error pages without a manual restart.
+        checksum/config: {{ include (print $.Template.BasePath "/error-page/configmap.yaml") . | sha256sum }}
     spec:
       containers:
         - name: nginx

--- a/charts/auth/templates/jinbe/bootstrap-job.yaml
+++ b/charts/auth/templates/jinbe/bootstrap-job.yaml
@@ -61,6 +61,14 @@ spec:
         {{- include "auth.jinbe.podAnnotations" . | nindent 8 }}
     spec:
       restartPolicy: OnFailure
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.jinbe.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if and .Values.jinbe.enabled .Values.jinbe.serviceAccount.create }}
       serviceAccountName: {{ include "auth.jinbe.serviceAccountName" . }}
       {{- end }}
@@ -68,6 +76,10 @@ spec:
         - name: bootstrap
           image: "{{ .Values.jinbe.image.repository }}:{{ .Values.jinbe.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.jinbe.image.pullPolicy }}
+          {{- with .Values.jinbe.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           command: ["node", "dist/cli/bootstrap.js"]
           env:
             {{- include "auth.jinbe.env" . | nindent 12 }}

--- a/charts/auth/templates/jinbe/deployment.yaml
+++ b/charts/auth/templates/jinbe/deployment.yaml
@@ -21,6 +21,14 @@ spec:
       annotations:
         {{- include "auth.jinbe.podAnnotations" . | nindent 8 }}
     spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.jinbe.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if and .Values.jinbe.enabled .Values.jinbe.serviceAccount.create }}
       serviceAccountName: {{ include "auth.jinbe.serviceAccountName" . }}
       {{- end }}
@@ -35,6 +43,10 @@ spec:
         - name: bootstrap
           image: "{{ .Values.jinbe.image.repository }}:{{ .Values.jinbe.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.jinbe.image.pullPolicy }}
+          {{- with .Values.jinbe.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           command: ["node", "dist/cli/bootstrap.js"]
           env:
             {{- include "auth.jinbe.env" . | nindent 12 }}
@@ -49,6 +61,10 @@ spec:
         - name: jinbe
           image: "{{ .Values.jinbe.image.repository }}:{{ .Values.jinbe.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.jinbe.image.pullPolicy }}
+          {{- with .Values.jinbe.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 3000
@@ -58,11 +74,18 @@ spec:
             {{- include "auth.oathkeeper.enabledEnv" . | nindent 12 }}
             {{- include "auth.backup.env" . | nindent 12 }}
             {{- include "auth.jinbe.envRuntimeOnly" . | nindent 12 }}
+          # Probe timeouts are deliberately generous. /api/health does light
+          # dependency checks and, under load (the gateway also polls jinbe for
+          # its access rules), can exceed the 1s default — which was SIGTERMing
+          # a healthy-but-busy jinbe on the liveness probe and causing restart
+          # flapping. timeoutSeconds + a higher liveness failureThreshold give a
+          # momentarily-slow-but-alive jinbe room instead of killing it.
           startupProbe:
             httpGet:
               path: /api/health
               port: http
             periodSeconds: 5
+            timeoutSeconds: {{ .Values.jinbe.probes.timeoutSeconds | default 5 }}
             failureThreshold: 72
           readinessProbe:
             httpGet:
@@ -70,12 +93,16 @@ spec:
               port: http
             initialDelaySeconds: 10
             periodSeconds: 15
+            timeoutSeconds: {{ .Values.jinbe.probes.timeoutSeconds | default 5 }}
+            failureThreshold: {{ .Values.jinbe.probes.readiness.failureThreshold | default 3 }}
           livenessProbe:
             httpGet:
               path: /api/health
               port: http
-            initialDelaySeconds: 15
+            initialDelaySeconds: 30
             periodSeconds: 30
+            timeoutSeconds: {{ .Values.jinbe.probes.timeoutSeconds | default 5 }}
+            failureThreshold: {{ .Values.jinbe.probes.liveness.failureThreshold | default 6 }}
           {{- with .Values.jinbe.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/charts/auth/templates/jinbe/networkpolicy.yaml
+++ b/charts/auth/templates/jinbe/networkpolicy.yaml
@@ -11,11 +11,13 @@
     - Oathkeeper proxy pods         (production traffic on port 8080)
     - OPAL server pods              (datasource pulls)
     - OPAL client pods              (data fetch)
-    - kubelet / probes from any pod IP on the node (use a wide rule —
-      probes don't carry pod labels)
+    - Admin UI (kuma) pods          (when adminUi.enabled)
     - Optionally extra peers via .Values.jinbe.networkPolicy.extraIngress
 
-  All egress is allowed (jinbe needs Redis, Kratos, OPAL, OPA, GitHub, etc.).
+  Kubelet HTTP probes originate from the node and are NOT subject to pod
+  NetworkPolicy, so no explicit probe allowance is needed. Only Ingress is
+  restricted; egress is left unrestricted (jinbe needs Redis, Kratos, OPAL,
+  OPA, GitHub, etc.).
 */}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -31,28 +33,33 @@ spec:
     - Ingress
   ingress:
     - from:
-        # Oathkeeper proxy + api pods (kratos chart standard labels)
+        # Oathkeeper proxy pods (ory oathkeeper subchart labels: the chart
+        # name is NOT release-prefixed, so app.kubernetes.io/name=oathkeeper).
         - podSelector:
             matchLabels:
               app.kubernetes.io/name: oathkeeper
               app.kubernetes.io/instance: {{ .Release.Name }}
-        # OPAL server (calls /api/admin/rbac/opal-datasource etc.)
+        # OPAL server (calls /api/admin/rbac/opal-datasource etc.). The opal
+        # subchart's app.kubernetes.io/name is release-prefixed, so match the
+        # stable opal.ac/role label instead; instance IS carried by opal pods.
         - podSelector:
             matchLabels:
-              app.kubernetes.io/name: opal-server
+              opal.ac/role: server
               app.kubernetes.io/instance: {{ .Release.Name }}
         # OPAL client (calls /api/admin/rbac/opal/* and /bindings)
         - podSelector:
             matchLabels:
-              app.kubernetes.io/name: opal-client
+              opal.ac/role: client
               app.kubernetes.io/instance: {{ .Release.Name }}
         # Admin UI (kuma) — proxies API calls to jinbe via oathkeeper, but
-        # keep direct path open for in-namespace SPA backend calls.
+        # keep direct path open for in-namespace SPA backend calls. The
+        # admin-ui pods only carry component + instance labels (no
+        # app.kubernetes.io/name), so match exactly those two.
         {{- if .Values.adminUi.enabled }}
         - podSelector:
             matchLabels:
-              {{- include "auth.selectorLabels" . | nindent 14 }}
               app.kubernetes.io/component: admin-ui
+              app.kubernetes.io/instance: {{ .Release.Name }}
         {{- end }}
         {{- with .Values.jinbe.networkPolicy.extraIngress }}
         {{- toYaml . | nindent 8 }}

--- a/charts/auth/templates/opa-authz-proxy/deployment.yaml
+++ b/charts/auth/templates/opa-authz-proxy/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       {{- end }}
       containers:
         - name: opa-authz-proxy
-          image: "{{ .Values.opaAuthzProxy.image.repository }}:{{ .Values.opaAuthzProxy.image.tag }}"
+          image: "{{ .Values.opaAuthzProxy.image.repository }}:{{ .Values.opaAuthzProxy.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.opaAuthzProxy.image.pullPolicy }}
           ports:
             - name: http

--- a/charts/auth/templates/redis/networkpolicy.yaml
+++ b/charts/auth/templates/redis/networkpolicy.yaml
@@ -1,0 +1,63 @@
+{{- if and .Values.redis.enabled .Values.redisNetworkPolicy.enabled }}
+{{/*
+  Redis NetworkPolicy (parent-chart, defense-in-depth) — restrict ingress to
+  the bundled bitnami redis so only intended callers can reach it. The bitnami
+  subchart's own NetworkPolicy is disabled (redis.networkPolicy.enabled=false)
+  because its default allowExternal=true accepts any pod, and a co-located
+  second policy would only be additive (union). This policy is release-pinned.
+
+  Allowed ingress on the redis port:
+    - jinbe pods    (RBAC data store + audit streams; matches the Deployment
+                     pod, which also runs the inline bootstrap initContainer,
+                     and the optional standalone bootstrap Job — all carry the
+                     jinbe name + instance labels)
+    - OPAL server   (broadcaster, only connects when opal.server.broadcastUri
+                     is set; allowed pre-emptively)
+    - OPAL client   (allowed pre-emptively; does not connect by default)
+    - Optionally extra peers via .Values.redisNetworkPolicy.extraIngress
+
+  Kubelet probes are node-originated and NOT subject to pod NetworkPolicy, so
+  redis health checks are unaffected. Only Ingress is restricted; egress is
+  left unrestricted.
+*/}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "auth.fullname" . }}-redis
+  labels:
+    {{- include "auth.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+spec:
+  podSelector:
+    matchLabels:
+      # bitnami labels redis pods with app.kubernetes.io/name = redis.nameOverride
+      # (default "redis"); honor an override (e.g. jinbe-redis) so the selector
+      # still matches when the bundled redis is renamed.
+      app.kubernetes.io/name: {{ .Values.redis.nameOverride | default "redis" }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        # jinbe (Deployment pod + inline bootstrap init + standalone Job pod)
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: {{ include "auth.name" . }}-jinbe
+              app.kubernetes.io/instance: {{ .Release.Name }}
+        # OPAL server (redis broadcaster when uvicornWorkers > 1)
+        - podSelector:
+            matchLabels:
+              opal.ac/role: server
+              app.kubernetes.io/instance: {{ .Release.Name }}
+        # OPAL client
+        - podSelector:
+            matchLabels:
+              opal.ac/role: client
+              app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- with .Values.redisNetworkPolicy.extraIngress }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      ports:
+        - protocol: TCP
+          port: 6379
+{{- end }}

--- a/charts/auth/values.yaml
+++ b/charts/auth/values.yaml
@@ -578,7 +578,11 @@ opal:
     policyRepoMainBranch: "main"
     pollingInterval: 30
     broadcastPgsql: false
-    broadcastUri: ""  # Required only when uvicornWorkers > 1 — redis://<release>-redis-master:6379
+    # Required only when uvicornWorkers > 1. Redis is password-protected
+    # (redis.auth.enabled=true), so the broadcast URI MUST embed the password:
+    #   redis://:<redis.auth.password>@<release>-redis-master:6379
+    # Leaving it empty (single worker) means OPAL never connects to redis.
+    broadcastUri: ""
     # Single worker → no need for inter-worker broadcast bus.
     # Increase + set broadcastUri when scaling.
     uvicornWorkers: 1
@@ -629,6 +633,11 @@ jinbe:
     create: true
     name: ""
     token: false
+    # Annotations added to the jinbe ServiceAccount. For the S3 backup feature
+    # (backup.enabled) set an IRSA role-arn here granting s3:PutObject +
+    # s3:GetObject + s3:ListBucket on the bucket, e.g.:
+    #   eks.amazonaws.com/role-arn: arn:aws:iam::ACCOUNT:role/auth-backup-role
+    annotations: {}
   # Jinbe image — REQUIRED override unless your cluster has a pull secret for
   # the W6D registry. The default below is private; a public release (e.g.
   # ghcr.io/w6d-io/jinbe:vX.Y.Z) will be wired in once published.
@@ -637,7 +646,7 @@ jinbe:
   #   --set jinbe.image.tag=latest
   image:
     repository: ghcr.io/w6d-io/jinbe
-    tag: v0.9.0
+    tag: v0.9.1
     pullPolicy: IfNotPresent
 
   service:
@@ -690,13 +699,50 @@ jinbe:
   # Pod annotations (e.g., for Vault integration)
   podAnnotations: {}
 
+  # Pod-level securityContext applied to BOTH the jinbe Deployment pod and the
+  # bootstrap Job pod. Empty by default so nothing is assumed about the image.
+  # Uncomment fields you need cluster-wide (e.g. fsGroup for a mounted volume).
+  podSecurityContext: {}
+    # fsGroup: 1000
+
+  # Container-level securityContext applied to the jinbe container, the inline
+  # bootstrap initContainer, and the standalone bootstrap Job container.
+  # SAFE hardening defaults that do NOT assume a particular image user, so they
+  # will not break boot. runAsNonRoot and readOnlyRootFilesystem are left
+  # COMMENTED on purpose: the jinbe image's runtime user and its writable-path
+  # requirements are unverified, and enabling either blind can crash the pod.
+  # Verify against the image, then uncomment.
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    seccompProfile:
+      type: RuntimeDefault
+    # runAsNonRoot: true
+    # readOnlyRootFilesystem: true
+
   resources:
     requests:
-      cpu: 100m
+      cpu: 200m
       memory: 128Mi
     limits:
-      cpu: 500m
+      # 1 core. 500m throttled jinbe's event loop under the gateway rule-poll +
+      # admin-UI fan-out, pushing /api/health past the probe timeout. Raised so
+      # health stays responsive under load.
+      cpu: "1"
       memory: 512Mi
+
+  # Health-probe tuning (consumed by jinbe/deployment.yaml). /api/health runs
+  # light dependency checks and can be slow under load; a too-tight timeout was
+  # SIGTERMing a busy-but-alive jinbe. Generous timeout + higher liveness
+  # failureThreshold prevent restart flapping. Override per-env if needed.
+  probes:
+    timeoutSeconds: 5
+    readiness:
+      failureThreshold: 3
+    liveness:
+      failureThreshold: 6
 
   # NetworkPolicy — restrict who can reach jinbe Service. Defence in depth:
   # jinbe authenticates exclusively via Kratos session cookie now (the proxy-
@@ -742,11 +788,46 @@ redis:
     registry: ghcr.io
     repository: w6d-io/redis
     tag: "8.2.2"
+  # Password authentication (requirepass) — OPT-IN, DEFAULT OFF. Enabling it on
+  # an EXISTING no-auth redis restarts the server AND requires wiring the OPAL
+  # broadcaster password (see opal.server.broadcastUri); flip it per-env
+  # deliberately, not as a blanket default. When enabled, every in-chart
+  # consumer that connects to redis is wired to the SAME password:
+  #   - jinbe: the auth.jinbe.env helper sources REDIS_PASSWORD from
+  #     redis.auth.password below and embeds it in REDIS_URL, so overriding
+  #     the password here alone propagates to jinbe (single source of truth).
+  #   - OPAL server broadcaster: only connects to redis when
+  #     opal.server.broadcastUri is set (uvicornWorkers > 1). It is empty by
+  #     default so OPAL never touches redis; IF you set broadcastUri you MUST
+  #     embed this password (see opal.server.broadcastUri).
+  # Replace the placeholder before production, or point at an existing secret
+  # via auth.existingSecret / auth.existingSecretPasswordKey. A `vault:` ref
+  # does NOT work here — the bitnami redis subchart is not Vault-aware and
+  # would set requirepass to the literal string.
   auth:
+    enabled: false
+    password: "changeme-redis-password"
+  # Disable the bitnami subchart's own NetworkPolicy: its default is
+  # allowExternal=true (accepts connections from any pod), and a second
+  # co-located NetworkPolicy would be additive (union), so it could not
+  # restrict anything. The parent chart ships a restrictive, release-pinned
+  # NetworkPolicy instead (templates/redis/networkpolicy.yaml, gated by
+  # redisNetworkPolicy.enabled) that allows only jinbe + OPAL pods.
+  networkPolicy:
     enabled: false
   master:
     persistence:
       size: 1Gi
+
+# Redis NetworkPolicy (parent-chart, defense-in-depth). Restricts ingress to
+# the bundled redis to jinbe + OPAL server/client pods on the redis port. Kept
+# OUT of the redis.* block so it does not collide with the bitnami subchart's
+# networkPolicy schema. Set enabled=false if your CNI doesn't support
+# NetworkPolicy. Only rendered when redis.enabled.
+redisNetworkPolicy:
+  enabled: true
+  # extraIngress: additional NetworkPolicyPeer entries appended to the rule.
+  extraIngress: []
 
 # =============================================================================
 # OPA AuthZ Proxy - Translates OPA decisions into HTTP status codes
@@ -785,7 +866,7 @@ opaAuthzProxy:
 # Kratos Login UI
 # =============================================================================
 kratosLoginUi:
-  # Public image at ghcr.io/w6d-io/kratos-login-ui:v0.1.0. Enabled by
+  # Public image at ghcr.io/w6d-io/kratos-login-ui:v0.2.0. Enabled by
   # default — the Oathkeeper rule `selfservice-ui` upstream points at
   # this Service, so auth/registration UI flows require it running.
   enabled: true
@@ -794,7 +875,7 @@ kratosLoginUi:
   image:
     repository: ghcr.io/w6d-io/kratos-login-ui
     pullPolicy: IfNotPresent
-    tag: "v0.1.2"
+    tag: "v0.2.0"
 
   branding:
     appName: "My App"
@@ -936,8 +1017,14 @@ adminUi:
     tag: v2.10.0
     pullPolicy: IfNotPresent
   env:
-    NEXT_PUBLIC_API_URL: ""  # Auto: https://app.{domain}
-    NEXT_PUBLIC_AUTH_URL: ""  # Auto: https://auth.{domain}
+    # API_BASE → the SPA's API origin. Empty = same-origin (kuma is served
+    # behind the same host/ingress as the API). Set to https://app.{domain}
+    # only for a split-origin deployment.
+    API_BASE: ""
+    # AUTH_DOMAIN → substituted into kuma's index.html at container start
+    # (envsubst → window.__AUTH_DOMAIN__); drives the 401 redirect target.
+    # Empty auto-derives from global.authDomain (or auth.<global.domain>).
+    AUTH_DOMAIN: ""
   extraEnv: {}
   podAnnotations: {}
   service:


### PR DESCRIPTION
Hardening on top of 0.9.3, validated by an in-place upgrade on a dev cluster. Pins jinbe v0.9.1 / kratos-login-ui v0.2.0 / kuma v2.10.0 / opa-authz v0.4.0. Fixes jinbe probe timeouts (1s default was restart-flapping a busy jinbe) + CPU headroom; NetworkPolicy peer-selector fixes (OPAL `opal.ac/role`, admin-ui component/instance, redis NP honors nameOverride); redis.auth opt-in default; vault podAnnotations merge; imagePullSecrets + safe securityContext for jinbe. See commit body for the full list.